### PR TITLE
Initial proof of concept for storing nonlinear functions.

### DIFF
--- a/src/MathOptFormat.jl
+++ b/src/MathOptFormat.jl
@@ -10,6 +10,10 @@ const Object = OrderedDict{String, Any}
 const MOI = MathOptInterface
 const MOIU = MOI.Utilities
 
+struct Nonlinear <: MOI.AbstractScalarFunction
+    expr::Expr
+end
+
 MOIU.@model(Model,
     (MOI.ZeroOne, MOI.Integer),
     (MOI.EqualTo, MOI.GreaterThan, MOI.LessThan, MOI.Interval,
@@ -22,7 +26,7 @@ MOIU.@model(Model,
         MOI.PositiveSemidefiniteConeTriangle, MOI.PositiveSemidefiniteConeSquare,
         MOI.ExponentialCone, MOI.DualExponentialCone),
     (MOI.PowerCone, MOI.DualPowerCone, MOI.SOS1, MOI.SOS2),
-    (MOI.SingleVariable,),
+    (MOI.SingleVariable, Nonlinear),
     (MOI.ScalarAffineFunction, MOI.ScalarQuadraticFunction),
     (MOI.VectorOfVariables,),
     (MOI.VectorAffineFunction, MOI.VectorQuadraticFunction)

--- a/src/MathOptFormat.jl
+++ b/src/MathOptFormat.jl
@@ -32,9 +32,6 @@ MOIU.@model(InnerModel,
     (MOI.VectorAffineFunction, MOI.VectorQuadraticFunction)
 )
 
-# TODO(odow): missing method in MOI/src/utilities/model.jl.
-MOI.supports(::InnerModel, ::MOI.ObjectiveFunctionType) = true
-
 const Model = MOIU.UniversalFallback{InnerModel{Float64}}
 
 """

--- a/src/MathOptFormat.jl
+++ b/src/MathOptFormat.jl
@@ -14,7 +14,7 @@ struct Nonlinear <: MOI.AbstractScalarFunction
     expr::Expr
 end
 
-MOIU.@model(Model,
+MOIU.@model(InnerModel,
     (MOI.ZeroOne, MOI.Integer),
     (MOI.EqualTo, MOI.GreaterThan, MOI.LessThan, MOI.Interval,
         MOI.Semicontinuous, MOI.Semiinteger),
@@ -32,18 +32,24 @@ MOIU.@model(Model,
     (MOI.VectorAffineFunction, MOI.VectorQuadraticFunction)
 )
 
+# TODO(odow): missing method in MOI/src/utilities/model.jl.
+MOI.supports(::InnerModel, ::MOI.ObjectiveFunctionType) = true
+
+const Model = MOIU.UniversalFallback{InnerModel{Float64}}
+
 """
     Model()
 
 Create an empty instance of MathOptFormat.Model.
 """
 function Model()
-    return Model{Float64}()
+    return MOIU.UniversalFallback(InnerModel{Float64}())
 end
+
+include("nonlinear.jl")
 
 include("read.jl")
 include("write.jl")
 
-include("nonlinear.jl")
 
 end

--- a/src/MathOptFormat.jl
+++ b/src/MathOptFormat.jl
@@ -40,4 +40,6 @@ end
 include("read.jl")
 include("write.jl")
 
+include("nonlinear.jl")
+
 end

--- a/src/MathOptFormat.jl
+++ b/src/MathOptFormat.jl
@@ -13,6 +13,7 @@ const MOIU = MOI.Utilities
 struct Nonlinear <: MOI.AbstractScalarFunction
     expr::Expr
 end
+Base.copy(nonlinear::Nonlinear) = Nonlinear(copy(nonlinear.expr))
 
 MOIU.@model(InnerModel,
     (MOI.ZeroOne, MOI.Integer),
@@ -41,6 +42,11 @@ Create an empty instance of MathOptFormat.Model.
 """
 function Model()
     return MOIU.UniversalFallback(InnerModel{Float64}())
+end
+
+function Base.show(io::IO, ::Model)
+    print(io, "A MathOptFormat Model")
+    return
 end
 
 include("nonlinear.jl")

--- a/src/nonlinear.jl
+++ b/src/nonlinear.jl
@@ -1,0 +1,151 @@
+#=
+    Expr:
+        2 * x + sin(x)^2 + y
+
+    Tree form:
+                    +-- (2)
+          +-- (*) --+
+          |         +-- (x)
+    (+) --+
+          |         +-- (sin) -+- (x)
+          +-- (^) --+
+          |         +-- (2)
+          |
+          +-- (y)
+
+    MOF format:
+
+        {
+            "objectives": [
+                {"sense": "max", "function": {"head": "node", "index": 4}}
+            ]
+            "node_list": [
+                {
+                    "head": "*", "args": [
+                        {"head": "constant", "value": 2},
+                        {"head": "variable", "name": "x"}
+                    ]
+                },
+                {
+                    "head": "sin",
+                    "args": [
+                        {"head": "variable", "name", "x"}
+                    ]
+                }
+                {
+                    "head": "^",
+                    "args": [
+                        {"head": "node", "index": 2},
+                        {"head": "constant", "value": 2}
+                    ]
+                },
+                {
+                    "head": "+",
+                    "args": [
+                        {"head": "node", "index": 1},
+                        {"head": "node", "index": 3},
+                        {"head": "variable", "name": "y"}
+                    ]
+                }
+            ]
+        }
+
+=#
+
+"""
+    FUNCTION_TO_STRING
+
+A dictionary that maps function names in Symbol form to their MathOptFormat
+string representation.
+
+If the list of functions that MathOptFormat supports is extended, a reverse
+entry should also be added to `STRING_TO_FUNCTION`.
+"""
+const FUNCTION_TO_STRING = Dict{Symbol, String}(
+    :+ => "+",
+    :- => "-",
+    :* => "*",
+    :/ => "/",
+    :^ => "^",
+    :sin => "sin"
+)
+
+"""
+    STRING_TO_FUNCTION
+
+A dictionary that maps function names in their MathOptFormat string
+representation to the symbol representing the Julia function.
+
+If the list of functions that MathOptFormat supports is extended, a reverse
+entry should also be added to `FUNCTION_TO_STRING`.
+"""
+const STRING_TO_FUNCTION = Dict{String, Symbol}(
+    "+" => :+,
+    "-" => :-,
+    "*" => :*,
+    "/" => :/,
+    "^" => :^,
+    "sin" => :sin
+)
+
+"""
+    convert_mof_to_expr(node::Object, node_list::Vector{Object})
+
+Convert a MathOptFormat node `node` into a Julia expression given a list of
+MathOptFormat nodes in `node_list`.
+"""
+function convert_mof_to_expr(node::Object, node_list::Vector{Object})
+    head = node["head"]
+    if head == "constant"
+        return node["value"]
+    elseif head == "variable"
+        return Symbol(node["name"])
+    elseif head == "node"
+        return convert_mof_to_expr(node_list[node["index"]], node_list)
+    else
+        if !haskey(STRING_TO_FUNCTION, head)
+            error("Cannot convert MOF to Expr. Unknown function: $(head).")
+        end
+        expr = Expr(:call)
+        push!(expr.args, STRING_TO_FUNCTION[head])
+        for arg in node["args"]
+            push!(expr.args, convert_mof_to_expr(arg, node_list))
+        end
+        return expr
+    end
+end
+
+"""
+    convert_mof_to_expr(node::Object, node_list::Vector{Object})
+
+Convert a Julia expression into a MathOptFormat representation. Any intermediate
+nodes that are required are appended to `node_list`.
+"""
+function convert_expr_to_mof(expr::Expr, node_list::Vector{Object})
+    if expr.head != :call
+        error("Expected an expression that was a function.")
+    end
+    function_name = expr.args[1]
+    if !haskey(FUNCTION_TO_STRING, function_name)
+        error("Cannot convert Expr to MOF. Unknown function: $(function_name).")
+    end
+    node = Object(
+        "head" => FUNCTION_TO_STRING[function_name],
+        "args" => Object[]
+    )
+    for arg in expr.args[2:end]
+        push!(node["args"], convert_expr_to_mof(arg, node_list))
+    end
+    push!(node_list, node)
+    return Object("head" => "node", "index" => length(node_list))
+end
+
+# Recursion end for variables.
+function convert_expr_to_mof(expr::Symbol, node_list::Vector{Object})
+    return Object("head" => "variable", "name" => String(expr))
+end
+
+# Recursion end for numeric constants.
+function convert_expr_to_mof(expr::Real, node_list::Vector{Object})
+    return Object("head" => "constant", "value" => expr)
+end

--- a/src/nonlinear.jl
+++ b/src/nonlinear.jl
@@ -74,11 +74,7 @@ The arity of a nonlinear function. One of:
  - `Unary` if the function accepts exactly one argument
  - `Binary` if the function accepts exactly two arguments.
 """
-@enum ARITY begin
-    Nary
-    Unary
-    Binary
-end
+@enum ARITY Nary Unary Binary
 
 # A nice error message telling the user they supplied the wrong number of
 # arguments to a nonlinear function.

--- a/src/nonlinear.jl
+++ b/src/nonlinear.jl
@@ -22,7 +22,7 @@
             "node_list": [
                 {
                     "head": "*", "args": [
-                        {"head": "constant", "value": 2},
+                        {"head": "real", "value": 2},
                         {"head": "variable", "name": "x"}
                     ]
                 },
@@ -36,7 +36,7 @@
                     "head": "^",
                     "args": [
                         {"head": "node", "index": 2},
-                        {"head": "constant", "value": 2}
+                        {"head": "real", "value": 2}
                     ]
                 },
                 {
@@ -53,40 +53,105 @@
 =#
 
 """
-    FUNCTION_TO_STRING
+    ARITY
 
-A dictionary that maps function names in Symbol form to their MathOptFormat
-string representation.
-
-If the list of functions that MathOptFormat supports is extended, a reverse
-entry should also be added to `STRING_TO_FUNCTION`.
+The arity of a nonlinear function. One of:
+ - `Nary` if the function accepts one or more arguments
+ - `Unary` if the function accepts exactly one argument
+ - `Binary` if the function accepts exactly two arguments.
 """
-const FUNCTION_TO_STRING = Dict{Symbol, String}(
-    :+ => "+",
-    :- => "-",
-    :* => "*",
-    :/ => "/",
-    :^ => "^",
-    :sin => "sin"
-)
+@enum ARITY begin
+    Nary
+    Unary
+    Binary
+end
+
+# A nice error message telling the user they supplied the wrong number of
+# arguments to a nonlinear function.
+function throw_invalid_arguments(function_name, function_type, num_arguments)
+    error("The function $(function_name) is an ($function_type) function, but" *
+          " you have passed $(num_arguments) arguments.")
+end
+
+function validate_arguments(function_name, actual::Int, required::ARITY)
+    if required == Nary && actual < 1
+        throw_invalid_arguments(function_name, "n-ary", actual)
+    elseif required == Unary && actual != 1
+        throw_invalid_arguments(function_name, "unary", actual)
+    elseif required == Binary && actual != 2
+        throw_invalid_arguments(function_name, "biary", actual)
+    end
+end
 
 """
-    STRING_TO_FUNCTION
+    SUPPORTED_FUNCTIONS
 
-A dictionary that maps function names in their MathOptFormat string
-representation to the symbol representing the Julia function.
-
-If the list of functions that MathOptFormat supports is extended, a reverse
-entry should also be added to `FUNCTION_TO_STRING`.
+A vector of string-symbol pairs that map the MathOptFormat string representation
+(i.e, the value of the `"head"` field) to the name of a Julia function (in
+Symbol form).
 """
-const STRING_TO_FUNCTION = Dict{String, Symbol}(
-    "+" => :+,
-    "-" => :-,
-    "*" => :*,
-    "/" => :/,
-    "^" => :^,
-    "sin" => :sin
-)
+const SUPPORTED_FUNCTIONS = Pair{String, Tuple{Symbol, ARITY}}[
+    # ==========================================================================
+    # The standard arithmetic functions.
+    # An n-ary function for addition: +(a, b, c) = a + b + c
+    "+" => (:+, Nary),
+    # An n-ary function for subtraction: -(a, b, c) = a - b - c
+    "-" => (:-, Nary),
+    # An n-ary function for multiplication: *(a, b, c) = a * b * c
+    "*" => (:*, Nary),
+    # A binary function for division. It must have exactly two arguments. The
+    # first argument is the numerator, the second argument is the denominator:
+    # /(a, b) = a / b.
+    "/" => (:/, Binary),
+    # ==========================================================================
+    # N-ary minimum and maximum functions.
+    "min" => (:min, Nary),
+    "max" => (:max, Nary),
+    # ==========================================================================
+    # The absolute value function: abs(x) = (x >= 0 ? x : -x).
+    "abs" => (:abs, Unary),
+    # ==========================================================================
+    # Log- and power-related functions.
+    # A binary function for exponentiation ^(a, b) = a ^ b.
+    "^" => (:^, Binary),
+    # The natural exponential function: exp(x) = e^x.
+    "exp" => (:exp, Unary),
+    # The base-e log function: y = log(x) => e^y = x.
+    "log" => (:log, Unary),
+    # The base-10 log function: y = log10(x) => 10^y = x.
+    "log10" => (:log10, Unary),
+    # The square root function: sqrt(x) = √x = x^(0.5).
+    "sqrt" => (:sqrt, Unary),
+    # ==========================================================================
+    # The unary trigonometric functions. These must have exactly one argument.
+    "cos" => (:cos, Unary),
+    "cosh" => (:cosh, Unary),
+    "acos" => (:acos, Unary),
+    "acosh" => (:acosh, Unary),
+    "sin" => (:sin, Unary),
+    "sinh" => (:sinh, Unary),
+    "asin" => (:asin, Unary),
+    "asinh" => (:asinh, Unary),
+    "tan" => (:tan, Unary),
+    "tanh" => (:tanh, Unary),
+    "atan" => (:atan, Unary),
+    "atanh" => (:atanh, Unary)
+]
+
+# An internal helper dictionary that maps function names in Symbol form to their
+# MathOptFormat string representation.
+const FUNCTION_TO_STRING = Dict{Symbol, Tuple{String, ARITY}}()
+
+# An internal helper dictionary that maps function names in their MathOptFormat
+# string representation to the symbol representing the Julia function.
+const STRING_TO_FUNCTION = Dict{String, Tuple{Symbol, ARITY}}()
+
+# Programatically add the list of supported functions to the helper dictionaries
+# for easy of look-up later.
+for (mathoptformat_string, (julia_symbol, num_arguments)) in SUPPORTED_FUNCTIONS
+    FUNCTION_TO_STRING[julia_symbol] = (mathoptformat_string, num_arguments)
+    STRING_TO_FUNCTION[mathoptformat_string] = (julia_symbol, num_arguments)
+end
 
 """
     convert_mof_to_expr(node::Object, node_list::Vector{Object})
@@ -96,8 +161,10 @@ MathOptFormat nodes in `node_list`.
 """
 function convert_mof_to_expr(node::Object, node_list::Vector{Object})
     head = node["head"]
-    if head == "constant"
+    if head == "real"
         return node["value"]
+    elseif head == "complex"
+        return Complex(node["real"], node["imag"])
     elseif head == "variable"
         return Symbol(node["name"])
     elseif head == "node"
@@ -106,8 +173,9 @@ function convert_mof_to_expr(node::Object, node_list::Vector{Object})
         if !haskey(STRING_TO_FUNCTION, head)
             error("Cannot convert MOF to Expr. Unknown function: $(head).")
         end
-        expr = Expr(:call)
-        push!(expr.args, STRING_TO_FUNCTION[head])
+        (julia_symbol, num_arguments) = STRING_TO_FUNCTION[head]
+        validate_arguments(head, length(node["args"]), num_arguments)
+        expr = Expr(:call, julia_symbol)
         for arg in node["args"]
             push!(expr.args, convert_mof_to_expr(arg, node_list))
         end
@@ -129,11 +197,13 @@ function convert_expr_to_mof(expr::Expr, node_list::Vector{Object})
     if !haskey(FUNCTION_TO_STRING, function_name)
         error("Cannot convert Expr to MOF. Unknown function: $(function_name).")
     end
+    (mathoptformat_string, num_arguments) = FUNCTION_TO_STRING[function_name]
+    validate_arguments(function_name, length(expr.args) - 1, num_arguments)
     node = Object(
-        "head" => FUNCTION_TO_STRING[function_name],
+        "head" => mathoptformat_string,
         "args" => Object[]
     )
-    for arg in expr.args[2:end]
+    for arg in @view(expr.args[2:end])
         push!(node["args"], convert_expr_to_mof(arg, node_list))
     end
     push!(node_list, node)
@@ -141,11 +211,17 @@ function convert_expr_to_mof(expr::Expr, node_list::Vector{Object})
 end
 
 # Recursion end for variables.
-function convert_expr_to_mof(expr::Symbol, node_list::Vector{Object})
-    return Object("head" => "variable", "name" => String(expr))
+function convert_expr_to_mof(sym::Symbol, node_list::Vector{Object})
+    return Object("head" => "variable", "name" => String(sym))
 end
 
-# Recursion end for numeric constants.
-function convert_expr_to_mof(expr::Real, node_list::Vector{Object})
-    return Object("head" => "constant", "value" => expr)
+# Recursion end for real constants.
+function convert_expr_to_mof(value::Real, node_list::Vector{Object})
+    return Object("head" => "real", "value" => value)
+end
+
+# Recursion end for complex numbers.
+function convert_expr_to_mof(value::Complex, node_list::Vector{Object})
+    return Object("head" => "complex", "real" => real(value),
+                  "imag" => imag(value))
 end

--- a/src/nonlinear.jl
+++ b/src/nonlinear.jl
@@ -63,11 +63,8 @@ function write_nlpblock(object::Object, model::Model,
     nlp_block = try
         MOI.get(model, MOI.NLPBlock())
     catch ex
-        if isa(ex, KeyError)
-            return  # No NLPBlock set.
-        else
-            rethrow(ex)
-        end
+        @assert isa(ex, KeyError)
+        return  # No NLPBlock set.
     end
     MOI.initialize(nlp_block.evaluator, [:ExprGraph])
     variables = MOI.get(model, MOI.ListOfVariableIndices())

--- a/src/read.jl
+++ b/src/read.jl
@@ -36,15 +36,19 @@ end
 
 function read_objectives(model::Model, object::Object,
                          name_map::Dict{String, MOI.VariableIndex})
-    if length(object["objectives"]) > 1
+    if length(object["objectives"]) == 0
+        MOI.set(model, MOI.ObjectiveSense(), MOI.FeasibilitySense)
+    elseif length(object["objectives"]) > 1
         error("Multi-objective models not supported by MathOptFormat.jl.")
+    else
+        objective = first(object["objectives"])
+        MOI.set(model, MOI.ObjectiveSense(),
+                read_objective_sense(objective["sense"]))
+        objective_type = MOI.get(model, MOI.ObjectiveFunctionType())
+        MOI.set(model, MOI.ObjectiveFunction{objective_type}(),
+                function_to_moi(objective["function"], model, name_map))
     end
-    objective = first(object["objectives"])
-    MOI.set(model, MOI.ObjectiveSense(),
-            read_objective_sense(objective["sense"]))
-    objective_type = MOI.get(model, MOI.ObjectiveFunctionType())
-    MOI.set(model, MOI.ObjectiveFunction{objective_type}(),
-            function_to_moi(objective["function"], model, name_map))
+    return
 end
 
 function read_constraints(model::Model, object::Object,
@@ -53,7 +57,9 @@ function read_constraints(model::Model, object::Object,
         foo = function_to_moi(constraint["function"], model, name_map)
         set = set_to_moi(constraint["set"], model, name_map)
         index = MOI.add_constraint(model, foo, set)
-        MOI.set(model, MOI.ConstraintName(), index, constraint["name"])
+        if haskey(constraint, "name")
+            MOI.set(model, MOI.ConstraintName(), index, constraint["name"])
+        end
     end
 end
 

--- a/src/read.jl
+++ b/src/read.jl
@@ -37,7 +37,7 @@ end
 function read_objectives(model::Model, object::Object,
                          name_map::Dict{String, MOI.VariableIndex})
     if length(object["objectives"]) == 0
-        MOI.set(model, MOI.ObjectiveSense(), MOI.FeasibilitySense)
+        MOI.set(model, MOI.ObjectiveSense(), MOI.FEASIBILITY_SENSE)
     elseif length(object["objectives"]) > 1
         error("Multi-objective models not supported by MathOptFormat.jl.")
     else

--- a/src/write.jl
+++ b/src/write.jl
@@ -7,6 +7,7 @@ function MOI.write_to_file(model::Model, filename::String)
         "constraints" => Object[]
     )
     name_map = write_variables(object, model)
+    write_nlpblock(object, model, name_map)
     write_objectives(object, model, name_map)
     write_constraints(object, model, name_map)
     open(filename, "w") do io
@@ -29,6 +30,11 @@ function write_objectives(object::Object, model::Model,
     sense = MOI.get(model, MOI.ObjectiveSense())
     objective_type = MOI.get(model, MOI.ObjectiveFunctionType())
     objective_function = MOI.get(model, MOI.ObjectiveFunction{objective_type}())
+    if (objective_type == MOI.ScalarAffineFunction{Float64} &&
+        length(objective_function.terms) == 0 &&
+        objective_function.constant == 0.0)
+            return  # The default objective. Don't include.
+    end
     push!(object["objectives"], Object(
         "sense"    => moi_to_object(sense),
         "function" => moi_to_object(objective_function, model, name_map)
@@ -66,10 +72,13 @@ function moi_to_object(index::MOI.ConstraintIndex{F,S}, model::Model,
                    name_map::Dict{MOI.VariableIndex, String}) where {F, S}
     func = MOI.get(model, MOI.ConstraintFunction(), index)
     set = MOI.get(model, MOI.ConstraintSet(), index)
+    object = Object("function" => moi_to_object(func, model, name_map),
+                    "set"      => moi_to_object(set, model, name_map))
     name = MOI.get(model, MOI.ConstraintName(), index)
-    return Object("function" => moi_to_object(func, model, name_map),
-                  "set"      => moi_to_object(set, model, name_map),
-                  "name"     => name)
+    if name != ""
+        object["name"] = name
+    end
+    return object
 end
 
 function moi_to_object(sense::MOI.OptimizationSense)

--- a/src/write.jl
+++ b/src/write.jl
@@ -86,7 +86,8 @@ function moi_to_object(sense::MOI.OptimizationSense)
         return "min"
     elseif sense == MOI.MAX_SENSE
         return "max"
-    elseif sense == MOI.FEASIBILITY_SENSE
+    else
+        @assert sense == MOI.FEASIBILITY_SENSE
         return "feasibility"
     end
 end

--- a/test/models/nlp.mof.json
+++ b/test/models/nlp.mof.json
@@ -1,0 +1,249 @@
+{
+  "name": "MathOptFormat Model",
+  "version": 0,
+  "variables": [
+    {
+      "name": "var_1"
+    },
+    {
+      "name": "var_2"
+    },
+    {
+      "name": "var_3"
+    },
+    {
+      "name": "var_4"
+    }
+  ],
+  "objectives": [
+    {
+      "sense": "min",
+      "function": {
+        "head": "Nonlinear",
+        "root": {
+          "head": "node",
+          "index": 3
+        },
+        "node_list": [
+          {
+            "head": "+",
+            "args": [
+              {
+                "head": "variable",
+                "name": "var_1"
+              },
+              {
+                "head": "variable",
+                "name": "var_2"
+              },
+              {
+                "head": "variable",
+                "name": "var_3"
+              }
+            ]
+          },
+          {
+            "head": "*",
+            "args": [
+              {
+                "head": "variable",
+                "name": "var_1"
+              },
+              {
+                "head": "variable",
+                "name": "var_4"
+              },
+              {
+                "head": "node",
+                "index": 1
+              }
+            ]
+          },
+          {
+            "head": "+",
+            "args": [
+              {
+                "head": "node",
+                "index": 2
+              },
+              {
+                "head": "variable",
+                "name": "var_3"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "constraints": [
+    {
+      "function": {
+        "head": "Nonlinear",
+        "root": {
+          "head": "node",
+          "index": 1
+        },
+        "node_list": [
+          {
+            "head": "*",
+            "args": [
+              {
+                "head": "variable",
+                "name": "var_1"
+              },
+              {
+                "head": "variable",
+                "name": "var_2"
+              },
+              {
+                "head": "variable",
+                "name": "var_3"
+              },
+              {
+                "head": "variable",
+                "name": "var_4"
+              }
+            ]
+          }
+        ]
+      },
+      "set": {
+        "head": "GreaterThan",
+        "lower": 25
+      }
+    },
+    {
+      "function": {
+        "head": "Nonlinear",
+        "root": {
+          "head": "node",
+          "index": 5
+        },
+        "node_list": [
+          {
+            "head": "^",
+            "args": [
+              {
+                "head": "variable",
+                "name": "var_1"
+              },
+              {
+                "head": "real",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "head": "^",
+            "args": [
+              {
+                "head": "variable",
+                "name": "var_2"
+              },
+              {
+                "head": "real",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "head": "^",
+            "args": [
+              {
+                "head": "variable",
+                "name": "var_3"
+              },
+              {
+                "head": "real",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "head": "^",
+            "args": [
+              {
+                "head": "variable",
+                "name": "var_4"
+              },
+              {
+                "head": "real",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "head": "+",
+            "args": [
+              {
+                "head": "node",
+                "index": 1
+              },
+              {
+                "head": "node",
+                "index": 2
+              },
+              {
+                "head": "node",
+                "index": 3
+              },
+              {
+                "head": "node",
+                "index": 4
+              }
+            ]
+          }
+        ]
+      },
+      "set": {
+        "head": "EqualTo",
+        "value": 40
+      }
+    },
+    {
+      "function": {
+        "head": "SingleVariable",
+        "variable": "var_1"
+      },
+      "set": {
+        "head": "Interval",
+        "lower": 1.0,
+        "upper": 5.0
+      }
+    },
+    {
+      "function": {
+        "head": "SingleVariable",
+        "variable": "var_2"
+      },
+      "set": {
+        "head": "Interval",
+        "lower": 1.0,
+        "upper": 5.0
+      }
+    },
+    {
+      "function": {
+        "head": "SingleVariable",
+        "variable": "var_3"
+      },
+      "set": {
+        "head": "Interval",
+        "lower": 1.0,
+        "upper": 5.0
+      }
+    },
+    {
+      "function": {
+        "head": "SingleVariable",
+        "variable": "var_4"
+      },
+      "set": {
+        "head": "Interval",
+        "lower": 1.0,
+        "upper": 5.0
+      }
+    }
+  ]
+}

--- a/test/nonlinear.jl
+++ b/test/nonlinear.jl
@@ -23,6 +23,9 @@ end
         # Test binary function with one arguments.
         @test_throws Exception MathOptFormat.convert_expr_to_mof(
             :(^(x)), node_list)
+        # An expression with something other than :call as the head.
+        @test_throws Exception MathOptFormat.convert_expr_to_mof(
+            :(a <= b <= c), node_list)
     end
     @testset "Roundtrip nonlinear expressions" begin
         for expression in [2, 2.34, 2 + 3im, :x, :(1 + x), :(x - 1), :(x + y),

--- a/test/nonlinear.jl
+++ b/test/nonlinear.jl
@@ -1,0 +1,57 @@
+function roundtrip_nonlinear_expression(expr)
+    node_list = MathOptFormat.Object[]
+    object = MathOptFormat.convert_expr_to_mof(expr, node_list)
+    @test MathOptFormat.convert_mof_to_expr(object, node_list) == expr
+end
+
+@testset "Nonlinear functions" begin
+    @testset "Error handling" begin
+        node_list = MathOptFormat.Object[]
+        # Test unsupported function for Expr -> MOF.
+        @test_throws Exception MathOptFormat.convert_expr_to_mof(
+            :(not_supported_function(x)), node_list)
+        # Test unsupported function for MOF -> Expr.
+        @test_throws Exception MathOptFormat.convert_mof_to_expr(
+            MathOptFormat.Object("head"=>"not_supported_function", "value"=>1),
+            node_list)
+        # Test n-ary function with no arguments.
+        @test_throws Exception MathOptFormat.convert_expr_to_mof(
+            :(min()), node_list)
+        # Test unary function with two arguments.
+        @test_throws Exception MathOptFormat.convert_expr_to_mof(
+            :(sin(x, y)), node_list)
+        # Test binary function with one arguments.
+        @test_throws Exception MathOptFormat.convert_expr_to_mof(
+            :(^(x)), node_list)
+    end
+    @testset "Roundtrip nonlinear expressions" begin
+        for expression in [2, 2.34, 2 + 3im, :x, :(1 + x), :(x - 1), :(x + y),
+                           :(x + y - z), :(2x), :(x * y), :(x / 2), :(2 / x),
+                           :(x / y), :(x / y / z), :(2^x), :(x^2), :(x^y),
+                           :(x^(2 * y + 1)), :(sin(x)), :(sin(x + y)),
+                           :(2x + sin(x)^2 + y), :(sin(3im)^2 + cos(3im)^2)]
+            roundtrip_nonlinear_expression(expression)
+        end
+    end
+    @testset "Reading and Writing" begin
+        # Write to file.
+        model = MathOptFormat.Model()
+        (x, y) = MOI.add_variables(model, 2)
+        MOI.set(model, MOI.VariableName(), x, "x")
+        MOI.set(model, MOI.VariableName(), y, "y")
+        con = MOI.add_constraint(model,
+                                 MathOptFormat.Nonlinear(:(2x + sin(x)^2 - y)),
+                                 MOI.EqualTo(1.0))
+        MOI.set(model, MOI.ConstraintName(), con, "con")
+        MOI.write_to_file(model, "test.mof.json")
+        # Read the model back in.
+        model2 = MathOptFormat.Model()
+        MOI.read_from_file(model2, "test.mof.json")
+        con2 = MOI.get(model2, MOI.ConstraintIndex, "con")
+        foo2 = MOI.get(model2, MOI.ConstraintFunction(), con2)
+        # Test that we recover the constraint.
+        @test foo2.expr == :(2x + sin(x)^2 - y)
+        @test MOI.get(model, MOI.ConstraintSet(), con) ==
+                MOI.get(model2, MOI.ConstraintSet(), con2)
+    end
+end

--- a/test/nonlinear.jl
+++ b/test/nonlinear.jl
@@ -7,7 +7,47 @@ function roundtrip_nonlinear_expression(expr, variable_to_string,
                                             string_to_variable) == expr
 end
 
+# hs071
+# min x1 * x4 * (x1 + x2 + x3) + x3
+# st  x1 * x2 * x3 * x4 >= 25
+#     x1^2 + x2^2 + x3^2 + x4^2 = 40
+#     1 <= x1, x2, x3, x4 <= 5
+struct ExprEvaluator <: MOI.AbstractNLPEvaluator
+    objective::Expr
+    constraints::Vector{Expr}
+end
+MOI.features_available(::ExprEvaluator) = [:ExprGraph]
+MOI.initialize(::ExprEvaluator, features) = nothing
+MOI.objective_expr(evaluator::ExprEvaluator) = evaluator.objective
+MOI.constraint_expr(evaluator::ExprEvaluator, i::Int) = evaluator.constraints[i]
+
+function HS071()
+    return MOI.NLPBlockData(
+        MOI.NLPBoundsPair.([25, 40], [Inf, 40]),
+        ExprEvaluator(:(x[1] * x[4] * (x[1] + x[2] + x[3]) + x[3]),
+                      [:(x[1] * x[2] * x[3] * x[4] >= 25),
+                       :(x[1]^2 + x[2]^2 + x[3]^2 + x[4]^2 == 40)]),
+        true)
+end
+
 @testset "Nonlinear functions" begin
+    @testset "HS071 via MOI" begin
+        model = MathOptFormat.Model()
+        x = MOI.add_variables(model, 4)
+        for (index, variable) in enumerate(x)
+            MOI.set(model, MOI.VariableName(), variable, "var_$(index)")
+        end
+        MOI.add_constraints(model, MOI.SingleVariable.(x),
+                            Ref(MOI.Interval(1.0, 5.0)))
+        MOI.set(model, MOI.NLPBlock(), HS071())
+        MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
+        MOI.write_to_file(model, "test.mof.json")
+        if VERSION >= v"0.7"
+            @test read("test.mof.json", String) == read("models/nlp.mof.json", String)
+        else
+            @test readstring("test.mof.json") == readstring("models/nlp.mof.json")
+        end
+    end
     @testset "Error handling" begin
         node_list = MathOptFormat.Object[]
         string_to_variable = Dict{String, MOI.VariableIndex}()

--- a/test/nonlinear.jl
+++ b/test/nonlinear.jl
@@ -1,50 +1,65 @@
-function roundtrip_nonlinear_expression(expr)
+function roundtrip_nonlinear_expression(expr, variable_to_string,
+                                        string_to_variable)
     node_list = MathOptFormat.Object[]
-    object = MathOptFormat.convert_expr_to_mof(expr, node_list)
-    @test MathOptFormat.convert_mof_to_expr(object, node_list) == expr
+    object = MathOptFormat.convert_expr_to_mof(expr, node_list,
+                                               variable_to_string)
+    @test MathOptFormat.convert_mof_to_expr(object, node_list,
+                                            string_to_variable) == expr
 end
 
 @testset "Nonlinear functions" begin
     @testset "Error handling" begin
         node_list = MathOptFormat.Object[]
+        string_to_variable = Dict{String, MOI.VariableIndex}()
+        variable_to_string = Dict{MOI.VariableIndex, String}()
         # Test unsupported function for Expr -> MOF.
         @test_throws Exception MathOptFormat.convert_expr_to_mof(
-            :(not_supported_function(x)), node_list)
+            :(not_supported_function(x)), node_list, variable_to_string)
         # Test unsupported function for MOF -> Expr.
         @test_throws Exception MathOptFormat.convert_mof_to_expr(
             MathOptFormat.Object("head"=>"not_supported_function", "value"=>1),
-            node_list)
+            node_list, string_to_variable)
         # Test n-ary function with no arguments.
         @test_throws Exception MathOptFormat.convert_expr_to_mof(
-            :(min()), node_list)
+            :(min()), node_list, variable_to_string)
         # Test unary function with two arguments.
         @test_throws Exception MathOptFormat.convert_expr_to_mof(
-            :(sin(x, y)), node_list)
+            :(sin(x, y)), node_list, variable_to_string)
         # Test binary function with one arguments.
         @test_throws Exception MathOptFormat.convert_expr_to_mof(
-            :(^(x)), node_list)
+            :(^(x)), node_list, variable_to_string)
         # An expression with something other than :call as the head.
         @test_throws Exception MathOptFormat.convert_expr_to_mof(
-            :(a <= b <= c), node_list)
+            :(a <= b <= c), node_list, variable_to_string)
+        # Hit the default fallback with an un-interpolated complex number.
+        @test_throws Exception MathOptFormat.convert_expr_to_mof(
+            :(1 + 2im), node_list, variable_to_string)
+
     end
     @testset "Roundtrip nonlinear expressions" begin
-        for expression in [2, 2.34, 2 + 3im, :x, :(1 + x), :(x - 1), :(x + y),
-                           :(x + y - z), :(2x), :(x * y), :(x / 2), :(2 / x),
-                           :(x / y), :(x / y / z), :(2^x), :(x^2), :(x^y),
-                           :(x^(2 * y + 1)), :(sin(x)), :(sin(x + y)),
-                           :(2x + sin(x)^2 + y), :(sin(3im)^2 + cos(3im)^2)]
-            roundtrip_nonlinear_expression(expression)
+        x = MOI.VariableIndex(123)
+        y = MOI.VariableIndex(456)
+        z = MOI.VariableIndex(789)
+        string_to_var = Dict{String, MOI.VariableIndex}("x"=>x, "y"=>y, "z"=>z)
+        var_to_string = Dict{MOI.VariableIndex, String}(x=>"x", y=>"y", z=>"z")
+        for expr in [2, 2.34, 2 + 3im, x, :(1 + $x), :($x - 1),
+                     :($x + $y), :($x + $y - $z), :(2 * $x), :($x * $y),
+                     :($x / 2), :(2 / $x), :($x / $y), :($x / $y / $z), :(2^$x),
+                     :($x^2), :($x^$y), :($x^(2 * $y + 1)), :(sin($x)),
+                     :(sin($x + $y)), :(2 * $x + sin($x)^2 + $y),
+                     :(sin($(3im))^2 + cos($(3im))^2), :($(1 + 2im) * $x)]
+            roundtrip_nonlinear_expression(expr, var_to_string, string_to_var)
         end
     end
     @testset "Reading and Writing" begin
         # Write to file.
         model = MathOptFormat.Model()
         (x, y) = MOI.add_variables(model, 2)
-        MOI.set(model, MOI.VariableName(), x, "x")
+        MOI.set(model, MOI.VariableName(), x, "var_x")
         MOI.set(model, MOI.VariableName(), y, "y")
         con = MOI.add_constraint(model,
-                                 MathOptFormat.Nonlinear(:(2x + sin(x)^2 - y)),
-                                 MOI.EqualTo(1.0))
+                 MathOptFormat.Nonlinear(:(2 * $x + sin($x)^2 - $y)),
+                 MOI.EqualTo(1.0))
         MOI.set(model, MOI.ConstraintName(), con, "con")
         MOI.write_to_file(model, "test.mof.json")
         # Read the model back in.
@@ -53,7 +68,7 @@ end
         con2 = MOI.get(model2, MOI.ConstraintIndex, "con")
         foo2 = MOI.get(model2, MOI.ConstraintFunction(), con2)
         # Test that we recover the constraint.
-        @test foo2.expr == :(2x + sin(x)^2 - y)
+        @test foo2.expr == :(2 * $x + sin($x)^2 - $y)
         @test MOI.get(model, MOI.ConstraintSet(), con) ==
                 MOI.get(model2, MOI.ConstraintSet(), con2)
     end

--- a/test/nonlinear.jl
+++ b/test/nonlinear.jl
@@ -76,7 +76,18 @@ end
         # Hit the default fallback with an un-interpolated complex number.
         @test_throws Exception MathOptFormat.convert_expr_to_mof(
             :(1 + 2im), node_list, variable_to_string)
-
+        # Invalid number of variables.
+        @test_throws Exception MathOptFormat.substitute_variables(
+            :(x[1] * x[2]), [MOI.VariableIndex(1)])
+        # Function-in-Set
+        @test_throws Exception MathOptFormat.extract_function_and_set(
+            :(foo in set))
+        # Not a constraint.
+        @test_throws Exception MathOptFormat.extract_function_and_set(:(x^2))
+        # Function-in-Set
+        @test MathOptFormat.extract_function_and_set(:(1 <= x <= 2)) ==
+            MathOptFormat.extract_function_and_set(:(2 >= x >= 1)) ==
+            (:x, MOI.Interval(1, 2))
     end
     @testset "Roundtrip nonlinear expressions" begin
         x = MOI.VariableIndex(123)

--- a/test/nonlinear.jl
+++ b/test/nonlinear.jl
@@ -40,12 +40,14 @@ end
         MOI.add_constraints(model, MOI.SingleVariable.(x),
                             Ref(MOI.Interval(1.0, 5.0)))
         MOI.set(model, MOI.NLPBlock(), HS071())
-        MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
+        MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
         MOI.write_to_file(model, "test.mof.json")
         if VERSION >= v"0.7"
-            @test read("test.mof.json", String) == read("models/nlp.mof.json", String)
+            @test read("test.mof.json", String) ==
+                read("models/nlp.mof.json", String)
         else
-            @test readstring("test.mof.json") == readstring("models/nlp.mof.json")
+            @test readstring("test.mof.json") ==
+                readstring("models/nlp.mof.json")
         end
     end
     @testset "Error handling" begin

--- a/test/nonlinear.jl
+++ b/test/nonlinear.jl
@@ -84,10 +84,13 @@ end
             :(foo in set))
         # Not a constraint.
         @test_throws Exception MathOptFormat.extract_function_and_set(:(x^2))
-        # Function-in-Set
+        # Two-sided constraints
         @test MathOptFormat.extract_function_and_set(:(1 <= x <= 2)) ==
             MathOptFormat.extract_function_and_set(:(2 >= x >= 1)) ==
             (:x, MOI.Interval(1, 2))
+        # Less-than constraint.
+        @test MathOptFormat.extract_function_and_set(:(x <= 2)) ==
+            (:x, MOI.LessThan(2))
     end
     @testset "Roundtrip nonlinear expressions" begin
         x = MOI.VariableIndex(123)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,8 @@ using MathOptFormat, Compat.Test
 const MOI = MathOptFormat.MOI
 const MOIU = MathOptFormat.MOIU
 
+include("nonlinear.jl")
+
 struct UnsupportedSet <: MOI.AbstractSet end
 struct UnsupportedFunction <: MOI.AbstractFunction end
 
@@ -13,43 +15,6 @@ function test_model_equality(model_string, variables, constraints)
     model_2 = MathOptFormat.Model()
     MOI.read_from_file(model_2, "test.mof.json")
     MOIU.test_models_equal(model, model_2, variables, constraints)
-end
-
-function roundtrip_nonlinear_expression(expr)
-    node_list = MathOptFormat.Object[]
-    object = MathOptFormat.convert_expr_to_mof(expr, node_list)
-    @test MathOptFormat.convert_mof_to_expr(object, node_list) == expr
-end
-
-@testset "Nonlinear functions" begin
-    @testset "Error handling" begin
-        node_list = MathOptFormat.Object[]
-        # Test unsupported function for Expr -> MOF.
-        @test_throws Exception MathOptFormat.convert_expr_to_mof(
-            :(not_supported_function(x)), node_list)
-        # Test unsupported function for MOF -> Expr.
-        @test_throws Exception MathOptFormat.convert_mof_to_expr(
-            MathOptFormat.Object("head"=>"not_supported_function", "value"=>1),
-            node_list)
-        # Test n-ary function with no arguments.
-        @test_throws Exception MathOptFormat.convert_expr_to_mof(
-            :(min()), node_list)
-        # Test unary function with two arguments.
-        @test_throws Exception MathOptFormat.convert_expr_to_mof(
-            :(sin(x, y)), node_list)
-        # Test binary function with one arguments.
-        @test_throws Exception MathOptFormat.convert_expr_to_mof(
-            :(^(x)), node_list)
-    end
-    @testset "Roundtrip nonlinear expressions" begin
-        for expression in [2, 2.34, 2 + 3im, :x, :(1 + x), :(x - 1), :(x + y),
-                           :(x + y - z), :(2x), :(x * y), :(x / 2), :(2 / x),
-                           :(x / y), :(x / y / z), :(2^x), :(x^2), :(x^y),
-                           :(x^(2 * y + 1)), :(sin(x)), :(sin(x + y)),
-                           :(2x + sin(x)^2 + y), :(sin(3im)^2 + cos(3im)^2)]
-            roundtrip_nonlinear_expression(expression)
-        end
-    end
 end
 
 @testset "Error handling: read_from_file" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,12 +21,34 @@ function roundtrip_nonlinear_expression(expr)
     @test MathOptFormat.convert_mof_to_expr(object, node_list) == expr
 end
 
-@testset "Roundtrip nonlinear expressions" begin
-    for expression in [2, 2.34, :x, :(1 + x), :(x - 1), :(x + y), :(x + y - z),
-                       :(2x), :(x * y), :(x / 2), :(2 / x), :(x / y),
-                       :(x / y / z), :(2^x), :(x^2), :(x^y), :(x^(2 * y + 1)),
-                       :(sin(x)), :(sin(x + y)), :(2x + sin(x)^2 + y)]
-        roundtrip_nonlinear_expression(expression)
+@testset "Nonlinear functions" begin
+    @testset "Error handling" begin
+        node_list = MathOptFormat.Object[]
+        # Test unsupported function for Expr -> MOF.
+        @test_throws Exception MathOptFormat.convert_expr_to_mof(
+            :(not_supported_function(x)), node_list)
+        # Test unsupported function for MOF -> Expr.
+        @test_throws Exception MathOptFormat.convert_mof_to_expr(
+            MathOptFormat.Object("head"=>"not_supported_function", "value"=>1),
+            node_list)
+        # Test n-ary function with no arguments.
+        @test_throws Exception MathOptFormat.convert_expr_to_mof(
+            :(min()), node_list)
+        # Test unary function with two arguments.
+        @test_throws Exception MathOptFormat.convert_expr_to_mof(
+            :(sin(x, y)), node_list)
+        # Test binary function with one arguments.
+        @test_throws Exception MathOptFormat.convert_expr_to_mof(
+            :(^(x)), node_list)
+    end
+    @testset "Roundtrip nonlinear expressions" begin
+        for expression in [2, 2.34, 2 + 3im, :x, :(1 + x), :(x - 1), :(x + y),
+                           :(x + y - z), :(2x), :(x * y), :(x / 2), :(2 / x),
+                           :(x / y), :(x / y / z), :(2^x), :(x^2), :(x^y),
+                           :(x^(2 * y + 1)), :(sin(x)), :(sin(x + y)),
+                           :(2x + sin(x)^2 + y), :(sin(3im)^2 + cos(3im)^2)]
+            roundtrip_nonlinear_expression(expression)
+        end
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,21 @@ function test_model_equality(model_string, variables, constraints)
     MOIU.test_models_equal(model, model_2, variables, constraints)
 end
 
+function roundtrip_nonlinear_expression(expr)
+    node_list = MathOptFormat.Object[]
+    object = MathOptFormat.convert_expr_to_mof(expr, node_list)
+    @test MathOptFormat.convert_mof_to_expr(object, node_list) == expr
+end
+
+@testset "Roundtrip nonlinear expressions" begin
+    for expression in [2, 2.34, :x, :(1 + x), :(x - 1), :(x + y), :(x + y - z),
+                       :(2x), :(x * y), :(x / 2), :(2 / x), :(x / y),
+                       :(x / y / z), :(2^x), :(x^2), :(x^y), :(x^(2 * y + 1)),
+                       :(sin(x)), :(sin(x + y)), :(2x + sin(x)^2 + y)]
+        roundtrip_nonlinear_expression(expression)
+    end
+end
+
 @testset "Error handling: read_from_file" begin
     @testset "non-empty_model" begin
         model = MathOptFormat.Model()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,8 @@ using MathOptFormat, Compat.Test
 const MOI = MathOptFormat.MOI
 const MOIU = MathOptFormat.MOIU
 
+@test sprint(show, MathOptFormat.Model()) == "A MathOptFormat Model"
+
 include("nonlinear.jl")
 
 struct UnsupportedSet <: MOI.AbstractSet end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -72,6 +72,32 @@ end
         @test MathOptFormat.moi_to_object(variable_index, model) ==
             MathOptFormat.Object("name" => "x1")
     end
+    @testset "FEASIBILITY_SENSE" begin
+        model = MathOptFormat.Model()
+        x = MOI.add_variable(model)
+        MOI.set(model, MOI.VariableName(), x, "x")
+        MOI.set(model, MOI.ObjectiveSense(), MOI.FEASIBILITY_SENSE)
+        MOI.set(model, MOI.ObjectiveFunction{MOI.SingleVariable}(),
+            MOI.SingleVariable(x))
+        MOI.write_to_file(model, "test.mof.json")
+        model_2 = MathOptFormat.Model()
+        MOI.read_from_file(model_2, "test.mof.json")
+        MOIU.test_models_equal(model, model_2, ["x"], String[])
+    end
+    @testset "Empty function term" begin
+        model = MathOptFormat.Model()
+        x = MOI.add_variable(model)
+        MOI.set(model, MOI.VariableName(), x, "x")
+        c = MOI.add_constraint(model,
+            MOI.ScalarAffineFunction(MOI.ScalarAffineTerm{Float64}[], 0.0),
+            MOI.GreaterThan(1.0)
+        )
+        MOI.set(model, MOI.ConstraintName(), c, "c")
+        MOI.write_to_file(model, "test.mof.json")
+        model_2 = MathOptFormat.Model()
+        MOI.read_from_file(model_2, "test.mof.json")
+        MOIU.test_models_equal(model, model_2, ["x"], ["c"])
+    end
     @testset "min objective" begin
         test_model_equality("""
             variables: x


### PR DESCRIPTION
Here is a proof of concept for how we might store the expression graph of nonlinear functions in MathOptFormat.

The design introduces four special node types:
 - `{"head": "real", "value": 1.0}`, for storing real coefficients
 - `{"head": "complex", "real": 1.0, "imag", 2.0}`, for storing complex coefficients
 - `{"head": "variable", "name": "x"}`, for storing a variable
 - `{"head": "node", "index": 1}`, for pointing to a node in the list of nodes

It also introduces a standard node that represents one of a list of pre-defined functions. For example, `1 + x` is:
```
{
    "head": "+",
    "args": [
        {"head": "real", "value": 1.0},
        {"head": "variable", "name": "x"}
    ]
}
```

Nonlinear functions are stored as a list of nodes, with the root node of the expression graph stored in the field `"root"`:
```
{
    "head": "nonlinear",
    "root": {"head": "node", "index", 2},
    "node_list": [
        ... a list of nodes ...
    ]
}
```