### PR TITLE
[LP][MOF][MPS] preprocess unique variable names

### DIFF
--- a/src/LP/LP.jl
+++ b/src/LP/LP.jl
@@ -1,7 +1,8 @@
 module LP
 
-using MathOptInterface
+import ..MathOptFormat
 
+import MathOptInterface
 const MOI = MathOptInterface
 const MOIU = MOI.Utilities
 
@@ -116,6 +117,7 @@ function write_objective(io::IO, model::Model)
 end
 
 function MOI.write_to_file(model::Model, io::IO)
+    MathOptFormat.create_unique_names(model)
     write_sense(io, model)
     write_objective(io, model)
     println(io, "subject to")

--- a/src/MOF/MOF.jl
+++ b/src/MOF/MOF.jl
@@ -2,11 +2,14 @@ module MOF
 
 const VERSION = 0
 
-using DataStructures, JSON, MathOptInterface
+using DataStructures, JSON
+
+import ..MathOptFormat
 
 # we use an ordered dict to make the JSON printing nicer
 const Object = OrderedDict{String, Any}
 
+import MathOptInterface
 const MOI = MathOptInterface
 const MOIU = MOI.Utilities
 

--- a/src/MOF/write.jl
+++ b/src/MOF/write.jl
@@ -6,6 +6,7 @@ function MOI.write_to_file(model::Model, io::IO)
         "objectives"  => Object[],
         "constraints" => Object[]
     )
+    MathOptFormat.create_unique_names(model)
     name_map = write_variables(object, model)
     write_nlpblock(object, model, name_map)
     write_objectives(object, model, name_map)
@@ -59,9 +60,7 @@ function moi_to_object end
 function moi_to_object(index::MOI.VariableIndex, model::Model)
     name = MOI.get(model, MOI.VariableName(), index)
     if name == ""
-        # TODO(odow): What happens if this is an existing name? We should
-        # generate a unique name here.
-        name = "x$(index.value)"
+        error("Variable name for $(index) cannot be blank in an MOF file.")
     end
     return Object("name" => name)
 end

--- a/src/MPS/MPS.jl
+++ b/src/MPS/MPS.jl
@@ -1,7 +1,8 @@
 module MPS
 
-using MathOptInterface
+import ..MathOptFormat
 
+import MathOptInterface
 const MOI = MathOptInterface
 const MOIU = MOI.Utilities
 
@@ -30,6 +31,7 @@ end
 # ==============================================================================
 
 function MOI.write_to_file(model::Model, io::IO)
+    MathOptFormat.create_unique_names(model)
     write_model_name(io, model)
     write_rows(io, model)
     write_columns(io, model)

--- a/src/MathOptFormat.jl
+++ b/src/MathOptFormat.jl
@@ -13,7 +13,7 @@ include("MPS/MPS.jl")
 """
     create_unique_names(model::MOI.ModelLike)
 
-
+Rename variables in `model` to ensure that all variables have a unique name.
 """
 function create_unique_names(model::MOI.ModelLike)
     variables = MOI.get(model, MOI.ListOfVariableIndices())

--- a/src/MathOptFormat.jl
+++ b/src/MathOptFormat.jl
@@ -18,8 +18,8 @@ function create_unique_names(model::MOI.ModelLike)
         while new_name in names
             new_name *= "_1"
         end
+        push!(names, new_name)
         if new_name != original_name
-            push!(names, new_name)
             if original_name == ""
                 @warn("Blank name detected for variable $(index). Renamed to " *
                       "$(new_name).")

--- a/test/MOF/MOF.jl
+++ b/test/MOF/MOF.jl
@@ -44,15 +44,7 @@ end
             joinpath(failing_models_dir, filename))
     end
 end
-
-@testset "round trips" begin
-    @testset "Empty model" begin
-        model = MOF.Model()
-        MOI.write_to_file(model, TEST_MOF_FILE)
-        model_2 = MOF.Model()
-        MOI.read_from_file(model_2, TEST_MOF_FILE)
-        MOIU.test_models_equal(model, model_2, String[], String[])
-    end
+@testset "Names" begin
     @testset "Blank variable name" begin
         model = MOF.Model()
         variable_index = MOI.add_variable(model)
@@ -60,6 +52,27 @@ end
         MathOptFormat.create_unique_names(model)
         @test MOF.moi_to_object(variable_index, model) ==
             MOF.Object("name" => "x1")
+    end
+    @testset "Duplicate variable name" begin
+        model = MOF.Model()
+        x = MOI.add_variable(model)
+        MOI.set(model, MOI.VariableName(), x, "x")
+        y = MOI.add_variable(model)
+        MOI.set(model, MOI.VariableName(), y, "x")
+        @test MOF.moi_to_object(x, model) == MOF.Object("name" => "x")
+        @test MOF.moi_to_object(y, model) == MOF.Object("name" => "x")
+        MathOptFormat.create_unique_names(model)
+        @test MOF.moi_to_object(x, model) == MOF.Object("name" => "x")
+        @test MOF.moi_to_object(y, model) == MOF.Object("name" => "x_1")
+    end
+end
+@testset "round trips" begin
+    @testset "Empty model" begin
+        model = MOF.Model()
+        MOI.write_to_file(model, TEST_MOF_FILE)
+        model_2 = MOF.Model()
+        MOI.read_from_file(model_2, TEST_MOF_FILE)
+        MOIU.test_models_equal(model, model_2, String[], String[])
     end
     @testset "FEASIBILITY_SENSE" begin
         model = MOF.Model()

--- a/test/MOF/MOF.jl
+++ b/test/MOF/MOF.jl
@@ -56,6 +56,8 @@ end
     @testset "Blank variable name" begin
         model = MOF.Model()
         variable_index = MOI.add_variable(model)
+        @test_throws Exception MOF.moi_to_object(variable_index, model)
+        MathOptFormat.create_unique_names(model)
         @test MOF.moi_to_object(variable_index, model) ==
             MOF.Object("name" => "x1")
     end


### PR DESCRIPTION
This addresses two points
 - Unnamed variables (i.e. name = `""`)
 - Variables with duplicate names are now allowed in MOI (https://github.com/JuliaOpt/MathOptInterface.jl/pull/549)

Closes #18