### PR TITLE
DNMY: [SOF] Begin schema for stochastic file format

### DIFF
--- a/src/SOF/example.sof.json
+++ b/src/SOF/example.sof.json
@@ -1,0 +1,163 @@
+{
+    "version": 0,
+    "author": "Oscar Dowson",
+    "description": "An example for StochasticOptFormat",
+    "root_node": {
+        "name": "ROOT",
+        "states": [{
+            "name": "volume",
+            "initial_value": 200.0
+        }]
+    },
+    "nodes": [{
+        "name": "stage_1",
+        "states": [{
+            "name": "volume",
+            "in": "volume_in",
+            "out": "volume_out"
+        }],
+        "noise_terms": [{
+            "probability": 0.3333333333333333,
+            "modifications": [{
+                "head": "NewSet",
+                "constraint": "volume_balance",
+                "new_set": {
+                    "head": "EqualTo",
+                    "value": 0.0
+                }
+            }]
+        }, {
+            "probability": 0.3333333333333333,
+            "modifications": [{
+                "head": "NewSet",
+                "constraint": "volume_balance",
+                "new_set": {
+                    "head": "EqualTo",
+                    "value": 50.0
+                }
+            }]
+        }, {
+            "probability": 0.3333333333333333,
+            "modifications": [{
+                "head": "NewSet",
+                "constraint": "volume_balance",
+                "new_set": {
+                    "head": "EqualTo",
+                    "value": 100.0
+                }
+            }]
+        }],
+        "model": {
+            "version": 0,
+            "variables": [{
+                "name": "volume_in"
+            }, {
+                "name": "volume_out"
+            }, {
+                "name": "thermal_generation"
+            }, {
+                "name": "hydro_generation"
+            }, {
+                "name": "hydro_spill"
+            }],
+            "objectives": [{
+                "sense": "min",
+                "function": {
+                    "head": "ScalarAffineFunction",
+                    "terms": [{
+                        "coefficient": 50,
+                        "variable": "thermal_generation"
+                    }],
+                    "constant": 0
+                }
+            }],
+            "constraints": [{
+                "name": "volume_balance",
+                "function": {
+                    "head": "ScalarAffineFunction",
+                    "terms": [{
+                        "coefficient": 1,
+                        "variable": "volume_out"
+                    }, {
+                        "coefficient": -1,
+                        "variable": "volume_in"
+                    }, {
+                        "coefficient": 1,
+                        "variable": "hydro_generation"
+                    }, {
+                        "coefficient": 1,
+                        "variable": "hydro_spill"
+                    }],
+                    "constant": 0
+                },
+                "set": {
+                    "head": "EqualTo",
+                    "value": 0
+                }
+            }, {
+                "name": "demand_constraint",
+                "function": {
+                    "head": "ScalarAffineFunction",
+                    "terms": [{
+                        "coefficient": 1,
+                        "variable": "thermal_generation"
+                    }, {
+                        "coefficient": 1,
+                        "variable": "hydro_generation"
+                    }],
+                    "constant": 0
+                },
+                "set": {
+                    "head": "EqualTo",
+                    "value": 150
+                }
+            }, {
+                "function": {
+                    "head": "SingleVariable",
+                    "variable": "volume_out"
+                },
+                "set": {
+                    "head": "Interval",
+                    "lower": 0,
+                    "upper": 200
+                }
+            }, {
+                "function": {
+                    "head": "SingleVariable",
+                    "variable": "thermal_generation"
+                },
+                "set": {
+                    "head": "GreaterThan",
+                    "lower": 0
+                }
+            }, {
+                "function": {
+                    "head": "SingleVariable",
+                    "variable": "hydro_generation"
+                },
+                "set": {
+                    "head": "GreaterThan",
+                    "lower": 0
+                }
+            }, {
+                "function": {
+                    "head": "SingleVariable",
+                    "variable": "hydro_spill"
+                },
+                "set": {
+                    "head": "GreaterThan",
+                    "lower": 0
+                }
+            }]
+        }
+    }],
+    "arcs": [{
+        "from": "ROOT",
+        "to": "stage_1",
+        "probability": 1.0
+    }, {
+        "from": "stage_1",
+        "to": "stage_1",
+        "probability": 0.9
+    }]
+}

--- a/src/SOF/stochastic.schema.json
+++ b/src/SOF/stochastic.schema.json
@@ -1,0 +1,184 @@
+{
+    "$schema": "https://json-schema.org/schema#",
+    "$id": "https://github.com/odow/MathOptFormat.jl/tree/master/src/stochastic.schema.json",
+    "title": "Multistage stochastic programming",
+    "type": "object",
+    "required": ["version", "root_node", "nodes", "arcs"],
+    "properties": {
+        "version": {
+            "const": 0
+        },
+        "author": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "root_node": {
+            "type": "object",
+            "required": ["name", "states"],
+            "properties": {
+                "name": {
+                    "description": "The name of the root node",
+                    "type": "string"
+                },
+                "states": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["name", "initial_value"],
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "initial_value": {
+                                "description": "The value of the state variable at the root node.",
+                                "type": "number"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "nodes": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["name", "states", "model"],
+                "properties": {
+                    "name": {
+                        "description": "The name of the node.",
+                        "type": "string"
+                    },
+                    "states": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "description": "The name of the state-variable in `#/root_node`.",
+                                    "type": "string"
+                                },
+                                "in": {
+                                    "description": "The name of the incoming state-variable.",
+                                    "type": "string"
+                                },
+                                "out": {
+                                    "description": "The name of the outgoing state-variable.",
+                                    "type": "string"
+                                },
+                            }
+                        }
+                    },
+                    "model": {
+                        "description": "A MathOptFormat model",
+                        "$ref": "https://github.com/odow/MathOptFormat.jl/tree/master/src/MOF/mof.schema.json#"
+                    },
+                    "noise_terms": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": ["probability", "modifications"],
+                            "properties": {
+                                "probability": {
+                                    "type": "number",
+                                    "minimum": 0.0,
+                                    "maximum": 1.0
+                                },
+                                "modifications": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/modification"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                }
+            }
+        },
+    },
+    "arcs": {
+        "type": "array",
+        "items": {
+            "type": "object",
+            "required": ["from", "to", "probability"],
+            "properties": {
+                "from": {
+                    "type": "string"
+                },
+                "to": {
+                    "type": "string"
+                },
+                "probability": {
+                    "type": "number",
+                    "minimum": 0.0,
+                    "maximum": 1.0
+                }
+            }
+        }
+    }
+},
+"definitions": {
+    "modification": {
+        "type": "object",
+        "required": ["head", "constraint"],
+        "properties": {
+            "constraint": {
+                "type": "name"
+            }
+        },
+        "oneOf": [{
+            "required": ["new_set"],
+            "properties": {
+                "head": {
+                    "const": "NewSet"
+                },
+                "new_set": {
+                    "oneOf": [{
+                        "$ref": "https://github.com/odow/MathOptFormat.jl/tree/master/src/MOF/mof.schema.json#/definitions/scalar_sets"
+                    }, {
+                        "$ref": "https://github.com/odow/MathOptFormat.jl/tree/master/src/MOF/mof.schema.json#/definitions/vector_sets"
+                    }]
+                }
+            }
+        }, {
+            "required": ["constant"],
+            "properties": {
+                "head": {
+                    "const": "ScalarConstantChange"
+                },
+                "constant": {
+                    "type": "number"
+                }
+            }
+        }, {
+            "required": ["constants"],
+            "properties": {
+                "head": {
+                    "const": "VectorConstantChange"
+                },
+                "constants": {
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                }
+            }
+        }, {
+            "required": ["coefficient", "variable"],
+            "properties": {
+                "head": {
+                    "const": "ScalarCoefficientChange"
+                },
+                "coefficient": {
+                    "type": "number"
+                },
+                "variable": {
+                    "type": "string"
+                }
+            }
+        }]
+    }
+}
+}


### PR DESCRIPTION
This PR is an exploratory look at how we could build a multistage stochastic file format out of nested MathOptFormat models (#47).

Based on the formulation outlined here: http://www.optimization-online.org/DB_HTML/2018/11/6914.html

Biggest question is to which modifications (#3) are incorporated into StochOptFormat, or whether they are natively supported in MOF.

cc @joaquimg @frapac @blegat