### PR TITLE
[MPS] only write BOUNDS if variable exists in COLUMNS

### DIFF
--- a/test/MPS/MPS.jl
+++ b/test/MPS/MPS.jl
@@ -256,6 +256,22 @@ end
             "SOS\n" *
             "ENDATA\n"
     end
+    @testset "Un-used variable" begin
+        # In this test, `x` will not be written to the file since it does not
+        # appear in the objective or in the constriants.
+        model = MPS.Model()
+        MOIU.loadfromstring!(model, """
+            variables: x, y
+            minobjective: y
+            c1: 2.0 * y >= 1.0
+            c2: x >= 0.0
+        """)
+        MOI.write_to_file(model, MPS_TEST_FILE)
+        @test MOI.get(model, MOI.NumberOfVariables()) == 2
+        model2 = MPS.Model()
+        MOI.read_from_file(model2, MPS_TEST_FILE)
+        @test MOI.get(model2, MOI.NumberOfVariables()) == 1
+    end
 end
 
 # Clean up


### PR DESCRIPTION
This PR implement's @DillonJ's [suggestion](https://github.com/odow/MathOptFormat.jl/issues/55#issuecomment-471338542) and omits variable bounds if the variable is not present in the COLUMNS section. This is needed because GAMS and CPLEX (and likely others) will throw an error when they run into this situation.

Closes #55