### PR TITLE
Ignore multiple objectives and fix FR bounds

### DIFF
--- a/src/MPS/MPS.jl
+++ b/src/MPS/MPS.jl
@@ -450,6 +450,7 @@ function MOI.read_from_file(model::Model, io::IO)
     end
     data = TempMPSModel()
     header = "NAME"
+    multi_objectives = String[]
     while !eof(io) && header != "ENDATA"
         line = strip(readline(io))
         if line == "" || startswith(line, "*")
@@ -466,9 +467,10 @@ function MOI.read_from_file(model::Model, io::IO)
             # A special case. This only happens at the start.
             parse_name_line(data, items)
         elseif header == "ROWS"
-            parse_rows_line(data, items)
+            multi_obj = parse_rows_line(data, items)
+            multi_obj !== nothing && push!(multi_objectives, multi_obj)
         elseif header == "COLUMNS"
-            parse_columns_line(data, items)
+            parse_columns_line(data, items, multi_objectives)
         elseif header == "RHS"
             parse_rhs_line(data, items)
         elseif header == "RANGES"
@@ -582,7 +584,7 @@ function parse_rows_line(data::TempMPSModel, items::Vector{String})
     data.rows[name] = row
     if sense == "N"
         if data.obj_name != ""
-            error("Multiple obectives encountered: $(join(items, " "))")
+            return name
         end
         data.obj_name = name
     end
@@ -594,17 +596,19 @@ end
 # ==============================================================================
 
 function parse_single_coefficient(data, row_name, column_name, value)
-    terms = data.rows[row_name].terms
-    value = parse(Float64, value)
-    if haskey(terms, column_name)
-        terms[column_name] += value
+    row = get(data.rows, row_name, nothing)
+    if row === nothing
+        error("ROW name $(row_name) not recognised. Is it in the ROWS field?")
+    end
+    if haskey(row.terms, column_name)
+        row.terms[column_name] += parse(Float64, value)
     else
-        terms[column_name] = value
+        row.terms[column_name] = parse(Float64, value)
     end
     return
 end
 
-function parse_columns_line(data::TempMPSModel, items::Vector{String})
+function parse_columns_line(data::TempMPSModel, items::Vector{String}, multi_objectives::Vector{String})
     if length(items) == 3
         # [column name] [row name] [value]
         column_name, row_name, value = items
@@ -614,6 +618,8 @@ function parse_columns_line(data::TempMPSModel, items::Vector{String})
         elseif uppercase(row_name) == "'MARKER'" &&
                 uppercase(value) == "'INTEND'"
             data.intorg_flag = false
+            return
+        elseif row_name in multi_objectives
             return
         end
         if !haskey(data.columns, column_name)
@@ -630,6 +636,9 @@ function parse_columns_line(data::TempMPSModel, items::Vector{String})
         column_name, row_name_1, value_1, row_name_2, value_2 = items
         if !haskey(data.columns, column_name)
             data.columns[column_name] = TempColumn()
+        end
+        if row_name_1 in multi_objectives || row_name_2 in multi_objectives
+            return
         end
         parse_single_coefficient(data, row_name_1, column_name, value_1)
         parse_single_coefficient(data, row_name_2, column_name, value_2)
@@ -779,6 +788,14 @@ function parse_bounds_line(data::TempMPSModel, items::Vector{String})
         elseif bound_type == "UI"
             column.upper = value
             column.is_int = true
+        elseif bound_type == "FR"
+            # So even though FR bounds should be of the form:
+            #  FR BOUND1    VARNAME
+            # there are cases in MIPLIB2017 (e.g., leo1 and leo2) like so:
+            #  FR BOUND1    C0000001       .000000
+            # In these situations, just ignore the value.
+            column.lower = -Inf
+            column.upper = Inf
         else
             error("Invalid bound type $(bound_type): $(join(items, " "))")
         end

--- a/src/MPS/MPS.jl
+++ b/src/MPS/MPS.jl
@@ -582,6 +582,14 @@ function parse_rows_line(data::TempMPSModel, items::Vector{String})
         error("Invalid row sense: $(join(items, " "))")
     end
     row = TempRow()
+    row.sense = sense
+    if sense == "N"
+        if data.obj_name != ""
+            # Detected a duplicate objective. Skip it.
+            return name
+        end
+        data.obj_name = name
+    end
     # Add some default bounds for the constraints.
     if sense == "G"
         row.lower = 0.0
@@ -591,14 +599,7 @@ function parse_rows_line(data::TempMPSModel, items::Vector{String})
         row.lower = 0.0
         row.upper = 0.0
     end
-    row.sense = sense
     data.rows[name] = row
-    if sense == "N"
-        if data.obj_name != ""
-            return name
-        end
-        data.obj_name = name
-    end
     return
 end
 

--- a/test/MPS/MPS.jl
+++ b/test/MPS/MPS.jl
@@ -131,6 +131,27 @@ end
             minobjective: x
         """, ["x"], String[])
     end
+    @testset "default RHS >=" begin
+        test_model_equality("""
+            variables: x
+            minobjective: x
+            c1: 2.0 * x >= 0.0
+        """, ["x"], ["c1"])
+    end
+    @testset "default RHS <=" begin
+        test_model_equality("""
+            variables: x
+            minobjective: x
+            c1: 2.0 * x <= 0.0
+        """, ["x"], ["c1"])
+    end
+    @testset "default RHS ==" begin
+        test_model_equality("""
+            variables: x
+            minobjective: x
+            c1: 2.0 * x == 0.0
+        """, ["x"], ["c1"])
+    end
     @testset "min scalaraffine" begin
         test_model_equality("""
             variables: x

--- a/test/MPS/MPS.jl
+++ b/test/MPS/MPS.jl
@@ -92,20 +92,24 @@ end
     MOI.set(model, MOI.ConstraintName(), MOI.get(model,
             MOI.ListOfConstraintIndices{MOI.SingleVariable, MOI.Interval{Float64}}())[1],
         "con6")
+    MOI.set(model, MOI.ConstraintName(), MOI.get(model,
+            MOI.ListOfConstraintIndices{MOI.SingleVariable, MOI.ZeroOne}())[1],
+        "con7")
     model_2 = MPS.Model()
     MOIU.loadfromstring!(model_2, """
-    variables: x, y
-    minobjective: x + y
+    variables: x, y, z
+    minobjective: x + y + z
     con1: 1.0 * x in Interval(1.0, 5.0)
     con2: 1.0 * x in Interval(2.0, 6.0)
     con3: 1.0 * x in Interval(3.0, 7.0)
     con4: 2.0 * x in Interval(4.0, 8.0)
     con5: y in Integer()
     con6: y in Interval(1.0, 4.0)
+    con7: z in ZeroOne()
     """)
     MOI.set(model_2, MOI.Name(), "stacked_data")
-    MOIU.test_models_equal(model, model_2, ["x", "y"],
-        ["con1", "con2", "con3", "con4", "con5", "con6"])
+    MOIU.test_models_equal(model, model_2, ["x", "y", "z"],
+        ["con1", "con2", "con3", "con4", "con5", "con6", "con7"])
 end
 
 @testset "free_integer" begin

--- a/test/MPS/failing_models/bounds_invalid_type2.mps
+++ b/test/MPS/failing_models/bounds_invalid_type2.mps
@@ -4,5 +4,5 @@ ROWS
 COLUMNS
     x         c                 1
 BOUNDS
- BV bounds    x                 1
+ PL bounds    x                 1
 ENDATA

--- a/test/MPS/failing_models/bounds_invalid_type2.mps
+++ b/test/MPS/failing_models/bounds_invalid_type2.mps
@@ -4,5 +4,5 @@ ROWS
 COLUMNS
     x         c                 1
 BOUNDS
- FR bounds    x                 1
+ BV bounds    x                 1
 ENDATA

--- a/test/MPS/failing_models/rows_duplicate_obj.mps
+++ b/test/MPS/failing_models/rows_duplicate_obj.mps
@@ -1,6 +1,0 @@
-NAME
-ROWS
- N  c
- N  d
-COLUMNS
-ENDATA

--- a/test/MPS/stacked_data.mps
+++ b/test/MPS/stacked_data.mps
@@ -8,6 +8,7 @@
 NAME stacked_data
 ROWS
  N  obj
+ N  blank_obj
  G  con1
  L  con2
  E  con3
@@ -18,6 +19,9 @@ COLUMNS
     x         con4      1
     x         con4      1
     y         obj       1
+    z         obj       1
+    x         blank_obj 1
+    y         blank_obj 1              blank_obj 1
 RHS
     rhs       con1      1              con2      6
     rhs       con3      3              con4      8
@@ -29,4 +33,5 @@ BOUNDS
  FR bounds    x         0
  UI bounds    y         4
  LI bounds    y         1
+ BV bounds    z         1
 ENDATA

--- a/test/MPS/stacked_data.mps
+++ b/test/MPS/stacked_data.mps
@@ -26,7 +26,7 @@ RANGES
     ranges    con3      4
     ranges    con4      -4
 BOUNDS
- FR bounds    x
+ FR bounds    x         0
  UI bounds    y         4
  LI bounds    y         1
 ENDATA


### PR DESCRIPTION
Fixes from attempting to parse MIPLIB2017
 - ignore multiple objectives
 - parse FR and BV bounds with specified values
 - add default RHS terms for `L`, `G` and `E` constraints