### PR TITLE
Prepare registration

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MathOptFormat"
 uuid = "f4570300-c277-12e8-125c-4912f86ce65d"
 authors = ["Oscar Dowson <oscar.dowson@northwestern.edu"]
-version = "0.0.0"
+version = "0.1.0"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
@@ -10,7 +10,18 @@ HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 JSONSchema = "7d188eb4-7ad8-530c-ae41-71a32a6d4692"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-julia = "1.0"
+julia = ">=1.0"
+DataStructures = ">= 0.15.0"
+GZip = ">= 0.5.0"
+HTTP = ">= 0.8.2"
+JSON = ">= 0.20.0"
+JSONSchema = ">= 0.1.1"
+MathOptInterface = ">= 0.8"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ GZip = ">= 0.5.0"
 HTTP = ">= 0.8.2"
 JSON = ">= 0.20.0"
 JSONSchema = ">= 0.1.1"
-MathOptInterface = "0.8, 0.9"
+MathOptInterface = "~0.8.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ GZip = ">= 0.5.0"
 HTTP = ">= 0.8.2"
 JSON = ">= 0.20.0"
 JSONSchema = ">= 0.1.1"
-MathOptInterface = ">= 0.8"
+MathOptInterface = "0.8, 0.9"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,0 @@
-julia 1
-DataStructures
-JSON
-GZip
-MathOptInterface 0.8-0.9

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -21,6 +21,6 @@ end
 
 # Update this tag whenever github.com/odow/MathOptFormat releases a new update to
 # the schema (providing that any code in this package is also updated).
-const SCHEMA_GIT_TAG = "v0.1.0-beta"
+const SCHEMA_GIT_TAG = "v0.1.0"
 
 download_schema(SCHEMA_GIT_TAG)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -21,6 +21,6 @@ end
 
 # Update this tag whenever github.com/odow/MathOptFormat releases a new update to
 # the schema (providing that any code in this package is also updated).
-const SCHEMA_GIT_TAG = "v0.0.0-beta"
+const SCHEMA_GIT_TAG = "v0.1.0-beta"
 
 download_schema(SCHEMA_GIT_TAG)

--- a/src/CBF/CBF.jl
+++ b/src/CBF/CBF.jl
@@ -1,6 +1,6 @@
 module CBF
 
-using MathOptInterface
+import MathOptInterface
 
 const MOI = MathOptInterface
 const MOIU = MOI.Utilities

--- a/src/MathOptFormat.jl
+++ b/src/MathOptFormat.jl
@@ -1,6 +1,6 @@
 module MathOptFormat
 
-using MathOptInterface
+import MathOptInterface
 const MOI = MathOptInterface
 
 import GZip


### PR DESCRIPTION
The tests are failing because  https://github.com/odow/MathOptFormat  needs a v0.1.0 to keep the versions consistent. Otherwise, once merged it can be registered. 

The [registration app](https://github.com/JuliaRegistries/Registrator.jl?installation_id=1112787&setup_action=install#how-to-use) needs to be installed and the [tag bot]( https://github.com/JuliaRegistries/TagBot) but I don't have permission to do that. 