### PR TITLE
LP sanitisation

### DIFF
--- a/src/LP/LP.jl
+++ b/src/LP/LP.jl
@@ -37,27 +37,12 @@ const MAX_LENGTH = 255
 const START_REG = r"^([\.0-9eE])"
 const NAME_REG = r"([^a-zA-Z0-9\!\"\#\$\%\&\(\)\/\,\.\;\?\@\_\`\'\{\}\|\~])"
 
-function verifyname(name::String)
-    if length(name) > MAX_LENGTH
-        return false
-    end
-    m = match(START_REG, name)
-    if m !== nothing
-        return false
-    end
-    m = match(NAME_REG, name)
-    if m !== nothing
-        return false
-    end
-    return true
-end
-
-function correctname(name::String)
+function sanitized_name(name::String)
     m = match(START_REG, name)
     if m !== nothing
         plural = length(m.match) > 1
         @warn("Name $(name) cannot start with a period, a number, e, or E. " *
-            "Prepending an underscore to name.")
+              "Prepending an underscore to name.")
         return correctname("_" * name)
     end
 
@@ -65,25 +50,22 @@ function correctname(name::String)
     if m !== nothing
         plural = length(m.match) > 1
         @warn("Name $(name) contains $(ifelse(plural, "", "an "))" *
-            "illegal character$(ifelse(plural, "s", "")): " *
-            "\"$(m.match)\". Removing the offending " *
-            "character$(ifelse(plural, "s", "")) from name.")
+              "illegal character$(ifelse(plural, "s", "")): " *
+              "\"$(m.match)\". Removing the offending " *
+              "character$(ifelse(plural, "s", "")) from name.")
         return correctname(replace(name, NAME_REG => s"_"))
     end
 
     # Truncate at the end to fit as many characters as possible.
     if length(name) > MAX_LENGTH
-        @warn("Name $(name) too long (length: $(length(name))). Truncating.", maxlog=1)
+        @warn("Name $(name) too long (length: $(length(name))). Truncating.")
         return correctname(String(name[1:MAX_LENGTH]))
     end
     return name
 end
 
 function write_function(io::IO, model::Model, func::MOI.SingleVariable)
-    name = MOI.get(model, MOI.VariableName(), func.variable)
-    if !verifyname(name)
-        name = correctname(name)
-    end
+    name = sanitized_name(MOI.get(model, MOI.VariableName(), func.variable))
     print(io, name)
     return
 end
@@ -104,10 +86,7 @@ function write_function(io::IO, model::Model, func::MOI.ScalarAffineFunction{Flo
                 Base.Grisu.print_shortest(io, abs(term.coefficient))
             end
 
-            varname = MOI.get(model, MOI.VariableName(), term.variable_index)
-            if !verifyname(varname)
-                varname = correctname(varname)
-            end
+            varname = sanitized_name(MOI.get(model, MOI.VariableName(), term.variable_index))
             print(io, " ", varname)
         end
     end

--- a/src/LP/LP.jl
+++ b/src/LP/LP.jl
@@ -37,50 +37,40 @@ const MAX_LENGTH = 255
 const START_REG = r"^([\.0-9eE])"
 const NAME_REG = r"([^a-zA-Z0-9\!\"\#\$\%\&\(\)\/\,\.\;\?\@\_\`\'\{\}\|\~])"
 
-let variable_name_cache = Dict{String, String}()
-    global sanitized_name
-    function sanitized_name(name::String)
-        if name in keys(variable_name_cache)
-            return variable_name_cache[name]
-        end
-        varname = name
-
-        m = match(START_REG, name)
-        if m !== nothing
-            plural = length(m.match) > 1
-            @warn("Name $(name) cannot start with a period, a number, e, or E. " *
-                  "Prepending an underscore to name.")
-            return sanitized_name("_" * name)
-        end
-
-        m = match(NAME_REG, name)
-        if m !== nothing
-            plural = length(m.match) > 1
-            @warn("Name $(name) contains $(ifelse(plural, "", "an "))" *
-                  "illegal character$(ifelse(plural, "s", "")): " *
-                  "\"$(m.match)\". Removing the offending " *
-                  "character$(ifelse(plural, "s", "")) from name.")
-            return sanitized_name(replace(name, NAME_REG => s"_"))
-        end
-
-        # Truncate at the end to fit as many characters as possible.
-        if length(name) > MAX_LENGTH
-            @warn("Name $(name) too long (length: $(length(name))). Truncating.")
-            return sanitized_name(String(name[1:MAX_LENGTH]))
-        end
-
-        variable_name_cache[varname] = name
-        return name
+function sanitized_name(name::String)
+    m = match(START_REG, name)
+    if m !== nothing
+        plural = length(m.match) > 1
+        @warn("Name $(name) cannot start with a period, a number, e, or E. " *
+              "Prepending an underscore to name.")
+        return sanitized_name("_" * name)
     end
+
+    m = match(NAME_REG, name)
+    if m !== nothing
+        plural = length(m.match) > 1
+        @warn("Name $(name) contains $(ifelse(plural, "", "an "))" *
+              "illegal character$(ifelse(plural, "s", "")): " *
+              "\"$(m.match)\". Removing the offending " *
+              "character$(ifelse(plural, "s", "")) from name.")
+        return sanitized_name(replace(name, NAME_REG => s"_"))
+    end
+
+    # Truncate at the end to fit as many characters as possible.
+    if length(name) > MAX_LENGTH
+        @warn("Name $(name) too long (length: $(length(name))). Truncating.")
+        return sanitized_name(String(name[1:MAX_LENGTH]))
+    end
+
+    return name
 end
 
-function write_function(io::IO, model::Model, func::MOI.SingleVariable)
-    name = sanitized_name(MOI.get(model, MOI.VariableName(), func.variable))
-    print(io, name)
+function write_function(io::IO, model::Model, func::MOI.SingleVariable, sanitized_names::Dict{MOI.VariableIndex, String})
+    print(io, sanitized_names[func.variable])
     return
 end
 
-function write_function(io::IO, model::Model, func::MOI.ScalarAffineFunction{Float64})
+function write_function(io::IO, model::Model, func::MOI.ScalarAffineFunction{Float64}, sanitized_names::Dict{MOI.VariableIndex, String})
     is_first_item = true
     if !(func.constant ≈ 0.0)
         Base.Grisu.print_shortest(io, func.constant)
@@ -96,8 +86,7 @@ function write_function(io::IO, model::Model, func::MOI.ScalarAffineFunction{Flo
                 Base.Grisu.print_shortest(io, abs(term.coefficient))
             end
 
-            varname = sanitized_name(MOI.get(model, MOI.VariableName(), term.variable_index))
-            print(io, " ", varname)
+            print(io, " ", sanitized_names[term.variable_index])
         end
     end
     return
@@ -139,14 +128,14 @@ end
 
 write_constraint_prefix(io::IO, set) = nothing
 
-function write_constraint(io::IO, model::Model, index; write_name::Bool = true)
+function write_constraint(io::IO, model::Model, index, sanitized_names::Dict{MOI.VariableIndex, String}; write_name::Bool = true)
     func = MOI.get(model, MOI.ConstraintFunction(), index)
     set = MOI.get(model, MOI.ConstraintSet(), index)
     if write_name
         print(io, MOI.get(model, MOI.ConstraintName(), index), ": ")
     end
     write_constraint_prefix(io, set)
-    write_function(io, model, func)
+    write_function(io, model, func, sanitized_names)
     write_constraint_suffix(io, set)
 end
 
@@ -164,30 +153,35 @@ function write_sense(io::IO, model::Model)
     return
 end
 
-function write_objective(io::IO, model::Model)
+function write_objective(io::IO, model::Model, sanitized_names::Dict{MOI.VariableIndex, String})
     print(io, "obj: ")
     obj_func_type = MOI.get(model, MOI.ObjectiveFunctionType())
     obj_func = MOI.get(model, MOI.ObjectiveFunction{obj_func_type}())
-    write_function(io, model, obj_func)
+    write_function(io, model, obj_func, sanitized_names)
     println(io)
     return
 end
 
 function MOI.write_to_file(model::Model, io::IO)
     MathOptFormat.create_unique_names(model)
+    sanitized_names = Dict{MOI.VariableIndex, String}()
+    for v in MOI.get(model, MOI.ListOfVariableIndices())
+        sanitized_names[v] = sanitized_name(MOI.get(model, MOI.VariableName(), v))
+    end
+
     write_sense(io, model)
-    write_objective(io, model)
+    write_objective(io, model, sanitized_names)
     println(io, "subject to")
     for S in SCALAR_SETS
         for index in MOI.get(model, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Float64}, S}())
-            write_constraint(io, model, index; write_name = true)
+            write_constraint(io, model, index, sanitized_names; write_name = true)
         end
     end
 
     println(io, "Bounds")
     for S in SCALAR_SETS
         for index in MOI.get(model, MOI.ListOfConstraintIndices{MOI.SingleVariable, S}())
-            write_constraint(io, model, index; write_name = false)
+            write_constraint(io, model, index, sanitized_names; write_name = false)
         end
     end
 
@@ -196,7 +190,7 @@ function MOI.write_to_file(model::Model, io::IO)
         if length(indices) > 0
             println(io, str_S)
             for index in indices
-                write_function(io, model, MOI.get(model, MOI.ConstraintFunction(), index))
+                write_function(io, model, MOI.get(model, MOI.ConstraintFunction(), index), sanitized_names)
                 println(io)
             end
         end

--- a/src/LP/LP.jl
+++ b/src/LP/LP.jl
@@ -57,9 +57,8 @@ function correctname(name::String)
     if m !== nothing
         plural = length(m.match) > 1
         @warn("Name $(name) cannot start with a period, a number, e, or E. " *
-            "Removing the offending character$(ifelse(plural, "s", "")) " *
-            "from name.", maxlog=1)
-        return correctname(replace(name, START_REG => s"_"))
+            "Prepending an underscore to name.")
+        return correctname("_" * name)
     end
 
     m = match(NAME_REG, name)
@@ -68,14 +67,14 @@ function correctname(name::String)
         @warn("Name $(name) contains $(ifelse(plural, "", "an "))" *
             "illegal character$(ifelse(plural, "s", "")): " *
             "\"$(m.match)\". Removing the offending " *
-            "character$(ifelse(plural, "s", "")) from name.", maxlog=1)
+            "character$(ifelse(plural, "s", "")) from name.")
         return correctname(replace(name, NAME_REG => s"_"))
     end
 
     # Truncate at the end to fit as many characters as possible.
     if length(name) > MAX_LENGTH
         @warn("Name $(name) too long (length: $(length(name))). Truncating.", maxlog=1)
-        return correctname(String(name[1:16]))
+        return correctname(String(name[1:MAX_LENGTH]))
     end
     return name
 end

--- a/test/LP/LP.jl
+++ b/test/LP/LP.jl
@@ -43,36 +43,22 @@ const LP_TEST_FILE = "test.lp"
     end
 
     @testset "Name sanitisation" begin
-        @testset "verifyname" begin
-            @test LP.verifyname("x")
-            @test LP.verifyname(repeat("x", LP.MAX_LENGTH))
-
-            @test LP.verifyname(repeat("x", LP.MAX_LENGTH + 1)) == false
-            @test LP.verifyname(".x") == false
-            @test LP.verifyname("0x") == false
-            @test LP.verifyname("exe") == false
-            @test LP.verifyname("ExE") == false
-
-            @test LP.verifyname("x^") == false
-            @test LP.verifyname("x*ds") == false
-        end
-
-        @testset "correctname" begin
-            @test LP.correctname("x") == "x"
-            @test LP.correctname(repeat("x", LP.MAX_LENGTH)) == repeat("x", LP.MAX_LENGTH)
+        @testset "sanitized_name" begin
+            @test LP.sanitized_name("x") == "x"
+            @test LP.sanitized_name(repeat("x", LP.MAX_LENGTH)) == repeat("x", LP.MAX_LENGTH)
 
             too_long = repeat("x", LP.MAX_LENGTH + 1)
-            @test (@test_logs (:warn, "Name $(too_long) too long (length: $(length(too_long))). Truncating.") LP.correctname(too_long)) == repeat("x", LP.MAX_LENGTH)
+            @test (@test_logs (:warn, "Name $(too_long) too long (length: $(length(too_long))). Truncating.") LP.sanitized_name(too_long)) == repeat("x", LP.MAX_LENGTH)
 
-            @test (@test_logs (:warn, "Name .x cannot start with a period, a number, e, or E. Prepending an underscore to name.") LP.correctname(".x")) == "_.x"
-            @test (@test_logs (:warn, "Name 0x cannot start with a period, a number, e, or E. Prepending an underscore to name.") LP.correctname("0x")) == "_0x"
-            @test (@test_logs (:warn, "Name Ex cannot start with a period, a number, e, or E. Prepending an underscore to name.") LP.correctname("Ex")) == "_Ex"
-            @test (@test_logs (:warn, "Name ex cannot start with a period, a number, e, or E. Prepending an underscore to name.") LP.correctname("ex")) == "_ex"
+            @test (@test_logs (:warn, "Name .x cannot start with a period, a number, e, or E. Prepending an underscore to name.") LP.sanitized_name(".x")) == "_.x"
+            @test (@test_logs (:warn, "Name 0x cannot start with a period, a number, e, or E. Prepending an underscore to name.") LP.sanitized_name("0x")) == "_0x"
+            @test (@test_logs (:warn, "Name Ex cannot start with a period, a number, e, or E. Prepending an underscore to name.") LP.sanitized_name("Ex")) == "_Ex"
+            @test (@test_logs (:warn, "Name ex cannot start with a period, a number, e, or E. Prepending an underscore to name.") LP.sanitized_name("ex")) == "_ex"
 
-            @test (@test_logs (:warn, "Name x*ds contains an illegal character: \"*\". Removing the offending character from name.") LP.correctname("x*ds")) == "x_ds"
-            @test (@test_logs (:warn, "Name x^ contains an illegal character: \"^\". Removing the offending character from name.") LP.correctname("x^")) == "x_"
-            @test (@test_logs (:warn, "Name x*ds[1] contains an illegal character: \"*\". Removing the offending character from name.") LP.correctname("x*ds[1]")) == "x_ds_1_"
-            @test (@test_logs (:warn, "Name Ex*ds[1] cannot start with a period, a number, e, or E. Prepending an underscore to name.") (:warn, "Name _Ex*ds[1] contains an illegal character: \"*\". Removing the offending character from name.") LP.correctname("Ex*ds[1]")) == "_Ex_ds_1_"
+            @test (@test_logs (:warn, "Name x*ds contains an illegal character: \"*\". Removing the offending character from name.") LP.sanitized_name("x*ds")) == "x_ds"
+            @test (@test_logs (:warn, "Name x^ contains an illegal character: \"^\". Removing the offending character from name.") LP.sanitized_name("x^")) == "x_"
+            @test (@test_logs (:warn, "Name x*ds[1] contains an illegal character: \"*\". Removing the offending character from name.") LP.sanitized_name("x*ds[1]")) == "x_ds_1_"
+            @test (@test_logs (:warn, "Name Ex*ds[1] cannot start with a period, a number, e, or E. Prepending an underscore to name.") (:warn, "Name _Ex*ds[1] contains an illegal character: \"*\". Removing the offending character from name.") LP.sanitized_name("Ex*ds[1]")) == "_Ex_ds_1_"
         end
 
         @testset "Whole chain" begin

--- a/test/LP/LP.jl
+++ b/test/LP/LP.jl
@@ -28,18 +28,32 @@ const LP_TEST_FILE = "test.lp"
             "subject to\n" *
             "c5: 1.1 x <= 5.1\n" *
             "c6: -1.4 + 1.3 x >= -0.1\n" *
-            "c7: 1.6 + 1.5 a == 0.2\n" *
+            "c7: 1.6 + 1.5 a = 0.2\n" *
             "c8: 0.3 <= 1.8 + 1.7 a <= 0.4\n" *
             "Bounds\n" *
             "x <= 2\n" *
             "x >= -1\n" *
-            "y == 3\n" *
+            "y = 3\n" *
             "4 <= z <= 5\n" *
             "General\n" *
             "y\n" *
             "Binary\n" *
-            "x\n"
+            "x\n" *
+            "End\n"
     end
+
+    @testset "Name sanitisation" begin
+        model = LP.Model()
+        MOIU.loadfromstring!(model, """
+        variables: a
+        minobjective: a
+        c1: a >= -1.0
+        """)
+        MOI.set(model, MOI.VariableName(), MOI.get(model, MOI.ListOfVariableIndices())[1], "a[]")
+
+        @test_logs (:warn, "Name a[] contains an illegal character: \"[\". Removing the offending character from name.") MOI.write_to_file(model, LP_TEST_FILE)
+    end
+
     @testset "other features" begin
         model = LP.Model()
         MOIU.loadfromstring!(model, """
@@ -51,7 +65,8 @@ const LP_TEST_FILE = "test.lp"
             "maximize\n" *
             "obj: -1 + 2 x\n" *
             "subject to\n" *
-            "Bounds\n"
+            "Bounds\n" *
+            "End\n"
     end
 end
 

--- a/test/LP/LP.jl
+++ b/test/LP/LP.jl
@@ -43,15 +43,49 @@ const LP_TEST_FILE = "test.lp"
     end
 
     @testset "Name sanitisation" begin
-        model = LP.Model()
-        MOIU.loadfromstring!(model, """
-        variables: a
-        minobjective: a
-        c1: a >= -1.0
-        """)
-        MOI.set(model, MOI.VariableName(), MOI.get(model, MOI.ListOfVariableIndices())[1], "a[]")
+        @testset "verifyname" begin
+            @test LP.verifyname("x")
+            @test LP.verifyname(repeat("x", LP.MAX_LENGTH))
 
-        @test_logs (:warn, "Name a[] contains an illegal character: \"[\". Removing the offending character from name.") MOI.write_to_file(model, LP_TEST_FILE)
+            @test LP.verifyname(repeat("x", LP.MAX_LENGTH + 1)) == false
+            @test LP.verifyname(".x") == false
+            @test LP.verifyname("0x") == false
+            @test LP.verifyname("exe") == false
+            @test LP.verifyname("ExE") == false
+
+            @test LP.verifyname("x^") == false
+            @test LP.verifyname("x*ds") == false
+        end
+
+        @testset "correctname" begin
+            @test LP.correctname("x") == "x"
+            @test LP.correctname(repeat("x", LP.MAX_LENGTH)) == repeat("x", LP.MAX_LENGTH)
+
+            too_long = repeat("x", LP.MAX_LENGTH + 1)
+            @test (@test_logs (:warn, "Name $(too_long) too long (length: $(length(too_long))). Truncating.") LP.correctname(too_long)) == repeat("x", LP.MAX_LENGTH)
+
+            @test (@test_logs (:warn, "Name .x cannot start with a period, a number, e, or E. Prepending an underscore to name.") LP.correctname(".x")) == "_.x"
+            @test (@test_logs (:warn, "Name 0x cannot start with a period, a number, e, or E. Prepending an underscore to name.") LP.correctname("0x")) == "_0x"
+            @test (@test_logs (:warn, "Name Ex cannot start with a period, a number, e, or E. Prepending an underscore to name.") LP.correctname("Ex")) == "_Ex"
+            @test (@test_logs (:warn, "Name ex cannot start with a period, a number, e, or E. Prepending an underscore to name.") LP.correctname("ex")) == "_ex"
+
+            @test (@test_logs (:warn, "Name x*ds contains an illegal character: \"*\". Removing the offending character from name.") LP.correctname("x*ds")) == "x_ds"
+            @test (@test_logs (:warn, "Name x^ contains an illegal character: \"^\". Removing the offending character from name.") LP.correctname("x^")) == "x_"
+            @test (@test_logs (:warn, "Name x*ds[1] contains an illegal character: \"*\". Removing the offending character from name.") LP.correctname("x*ds[1]")) == "x_ds_1_"
+            @test (@test_logs (:warn, "Name Ex*ds[1] cannot start with a period, a number, e, or E. Prepending an underscore to name.") (:warn, "Name _Ex*ds[1] contains an illegal character: \"*\". Removing the offending character from name.") LP.correctname("Ex*ds[1]")) == "_Ex_ds_1_"
+        end
+
+        @testset "Whole chain" begin
+            model = LP.Model()
+            MOIU.loadfromstring!(model, """
+            variables: a
+            minobjective: a
+            c1: a >= -1.0
+            """)
+            MOI.set(model, MOI.VariableName(), MOI.get(model, MOI.ListOfVariableIndices())[1], "a[]")
+
+            @test_logs (:warn, "Name a[] contains an illegal character: \"[\". Removing the offending character from name.") MOI.write_to_file(model, LP_TEST_FILE)
+        end
     end
 
     @testset "other features" begin


### PR DESCRIPTION
As I hit the same issue as #67, here is a fix, mostly taking code from LPWriter.jl. I had to change the API for the regex. 

Other changes: constraints must have a "=" sign, say CPLEX (documentation and interactive optimiser) and lp_solve (documentation only); add an End keyword, say CPLEX (interactive optimiser) and lp_solve (documentation).

For now, I just added one test case (I don't understand why it does not pass: the test framework seems to register the warning twice...). 

The case where multiple variables end up having the same name is not handled at all. I bumped the maximum name length to 255, as it's what CPLEX supports nowadays (and 16 is not enough for variables to have meaningful names, in my use cases). I guess this should be made configurable, in case someone needs shorter names (I hypothesise that most solvers will accept 255 characters). 