### PR TITLE
Fix copying between models

### DIFF
--- a/src/LP/LP.jl
+++ b/src/LP/LP.jl
@@ -208,6 +208,12 @@ end
 
 function MOI.write_to_file(model::Model, io::IO)
     options = MOI.get(model, MathOptFormat.ModelOptions())
+    if typeof(options) != Options
+        # Okay, we must have copied another MathOptFormat model here and it had
+        # some existing options. Reset to the default options.
+        options=  Options(255, false, false, Set{Char}(), Set{Char}())
+        MOI.set(model, MathOptFormat.ModelOptions(), options)
+    end
     max_length = options.maximum_length
     # Ensure each variable has a unique name that does not infringe LP constraints.
     MathOptFormat.create_unique_names(model, warn = options.warn)

--- a/src/MOF/write.jl
+++ b/src/MOF/write.jl
@@ -1,5 +1,11 @@
 function MOI.write_to_file(model::Model, io::IO)
     options = MOI.get(model, MathOptFormat.ModelOptions())
+    if typeof(options) != Options
+        # Okay, we must have copied another MathOptFormat model here and it had
+        # some existing options. Reset to the default options.
+        options = Options(false, true, false)
+        MOI.set(model, MathOptFormat.ModelOptions(), options)
+    end
     object = Object(
         "name"        => "MathOptFormat Model",
         "version"     => VERSION,

--- a/src/MPS/MPS.jl
+++ b/src/MPS/MPS.jl
@@ -56,6 +56,12 @@ end
 
 function MOI.write_to_file(model::Model, io::IO)
     options = MOI.get(model, MathOptFormat.ModelOptions())
+    if typeof(options) != Options
+        # Okay, we must have copied another MathOptFormat model here and it had
+        # some existing options. Reset to the default options.
+        options = Options(false)
+        MOI.set(model, MathOptFormat.ModelOptions(), options)
+    end
     MathOptFormat.create_unique_names(
         model, warn = options.warn, replacements = [' ' => '_']
     )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,3 +8,20 @@ const MOIU = MOI.Utilities
         include("$(file)/$(file).jl")
     end
 end
+
+@testset "Copying options" begin
+    models = [
+        MathOptFormat.CBF.Model,
+        MathOptFormat.LP.Model,
+        MathOptFormat.MOF.Model,
+        MathOptFormat.MPS.Model
+    ]
+    for src in models
+        model_src = src()
+        for dest in models
+            model_dest = dest()
+            MOI.copy_to(model_dest, model_src)
+            @test !isempty(sprint(io -> MOI.write_to_file(model_dest, io)))
+        end
+    end
+end


### PR DESCRIPTION
Since we use a `UniversalFallback`, lot's of things get inadvertently copied. On `write_to_file`, we need to check that the correct options have been set.