### PR TITLE
Switch from GZip.jl to CodecZlib.jl for handling I/O with gzipped files.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,8 +4,8 @@ authors = ["Oscar Dowson <oscar.dowson@northwestern.edu"]
 version = "0.2.1"
 
 [deps]
+CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-GZip = "92fee26a-97fe-5a0c-ad85-20a5f3185b63"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 JSONSchema = "7d188eb4-7ad8-530c-ae41-71a32a6d4692"

--- a/src/MathOptFormat.jl
+++ b/src/MathOptFormat.jl
@@ -3,7 +3,7 @@ module MathOptFormat
 import MathOptInterface
 const MOI = MathOptInterface
 
-import GZip
+import CodecZlib
 
 include("CBF/CBF.jl")
 include("LP/LP.jl")
@@ -135,9 +135,19 @@ end
 
 function gzip_open(f::Function, filename::String, mode::String)
     if endswith(filename, ".gz")
-        GZip.open(f, filename, mode)
+        if mode == "r"
+            open(CodecZlib.GzipDecompressorStream, filename, mode) do io
+                f(io)
+            end
+        elseif mode == "w"
+            open(CodecZlib.GzipCompressorStream, filename, mode) do io
+                f(io)
+            end
+        else
+            throw(ArgumentError("Mode must be \"r\" or \"w\""))
+        end
     else
-        return open(f, filename, mode)
+        open(f, filename, mode)
     end
 end
 

--- a/src/MathOptFormat.jl
+++ b/src/MathOptFormat.jl
@@ -147,7 +147,7 @@ function gzip_open(f::Function, filename::String, mode::String)
             throw(ArgumentError("Mode must be \"r\" or \"w\""))
         end
     else
-        open(f, filename, mode)
+        return open(f, filename, mode)
     end
 end
 

--- a/test/MOF/MOF.jl
+++ b/test/MOF/MOF.jl
@@ -9,14 +9,14 @@ include("nonlinear.jl")
 struct UnsupportedSet <: MOI.AbstractSet end
 struct UnsupportedFunction <: MOI.AbstractFunction end
 
-function test_model_equality(model_string, variables, constraints)
+function test_model_equality(model_string, variables, constraints; suffix="")
     model = MOF.Model()
     MOIU.loadfromstring!(model, model_string)
-    MOI.write_to_file(model, TEST_MOF_FILE)
+    MOI.write_to_file(model, TEST_MOF_FILE * suffix)
     model_2 = MOF.Model()
-    MOI.read_from_file(model_2, TEST_MOF_FILE)
+    MOI.read_from_file(model_2, TEST_MOF_FILE * suffix)
     MOIU.test_models_equal(model, model_2, variables, constraints)
-    MOF.validate(TEST_MOF_FILE)
+    MOF.validate(TEST_MOF_FILE * suffix)
 end
 
 @testset "read_from_file" begin
@@ -146,7 +146,7 @@ end
         test_model_equality("""
             variables: x
             maxobjective: x
-        """, ["x"], String[])
+        """, ["x"], String[], suffix=".gz")
     end
     @testset "min scalaraffine" begin
         test_model_equality("""
@@ -158,7 +158,7 @@ end
         test_model_equality("""
             variables: x
             maxobjective: 1.2x + 0.5
-        """, ["x"], String[])
+        """, ["x"], String[], suffix=".gz")
     end
     @testset "singlevariable-in-lower" begin
         test_model_equality("""
@@ -172,7 +172,7 @@ end
             variables: x
             maxobjective: 1.2x + 0.5
             c1: x <= 1.0
-        """, ["x"], ["c1"])
+        """, ["x"], ["c1"], suffix=".gz")
     end
     @testset "singlevariable-in-interval" begin
         test_model_equality("""

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,4 +26,15 @@ const MOIU = MOI.Utilities
             MOI.copy_to(model_dest, model_src)
         end
     end
+
+    @testset "Calling gzip_open" begin
+        @test_throws ArgumentError MathOptFormat.gzip_open((x) -> nothing,
+                                                           "dummy.gz", "a")
+        @test_throws ArgumentError MathOptFormat.gzip_open((x) -> nothing,
+                                                           "dummy.gz", "r+")
+        @test_throws ArgumentError MathOptFormat.gzip_open((x) -> nothing,
+                                                           "dummy.gz", "w+")
+        @test_throws ArgumentError MathOptFormat.gzip_open((x) -> nothing,
+                                                           "dummy.gz", "a+")
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,5 +36,6 @@ const MOIU = MOI.Utilities
                                                            "dummy.gz", "w+")
         @test_throws ArgumentError MathOptFormat.gzip_open((x) -> nothing,
                                                            "dummy.gz", "a+")
+        
     end
 end


### PR DESCRIPTION
GZip.jl has a bug on some Mac systems that prevents MathOptInterface from building; it also appears to not be maintained.