### PR TITLE
Add more compression formats

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.2.2"
 
 [deps]
 CodecBzip2 = "523fee87-0ab8-5b00-afb7-3ecf72e48cfd"
-CodecXz = "ba30903b-d9e8-5048-a5ec-d1f5b0d4b47b"
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,8 @@ authors = ["Oscar Dowson <oscar.dowson@northwestern.edu"]
 version = "0.2.2"
 
 [deps]
+CodecBzip2 = "523fee87-0ab8-5b00-afb7-3ecf72e48cfd"
+CodecXz = "ba30903b-d9e8-5048-a5ec-d1f5b0d4b47b"
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"

--- a/src/MOF/MOF.jl
+++ b/src/MOF/MOF.jl
@@ -90,8 +90,9 @@ Validate that the MOF file `filename` conforms to the MOF JSON schema. Returns
 `nothing` if the file is valid, otherwise throws an error describing why the
 file is not valid.
 """
-function validate(filename::String)
-    MathOptFormat.gzip_open(filename, "r") do io
+function validate(filename::String; compression::MathOptFormat.AbstractCompressionScheme=MathOptFormat.AutomaticCompression())
+    compression = MathOptFormat._automatic_compression(filename, compression)
+    MathOptFormat._compressed_open(filename, "r", compression) do io
         validate(io)
     end
     return

--- a/src/MathOptFormat.jl
+++ b/src/MathOptFormat.jl
@@ -7,6 +7,7 @@ import CodecBzip2
 import CodecXz
 import CodecZlib
 
+include("compression.jl")
 include("CBF/CBF.jl")
 include("LP/LP.jl")
 include("MOF/MOF.jl")

--- a/src/MathOptFormat.jl
+++ b/src/MathOptFormat.jl
@@ -167,25 +167,20 @@ function _filename_to_model(filename::String)
     return _file_formats[_filename_to_format(filename)][2]()
 end
 
-function gzip_open(f::Function, filename::String, mode::String; compression::AbstractCompressionScheme=AutomaticCompressionDetection())
-    if compression == AutomaticCompressionDetection()
-        compression = _filename_to_compression(filename)
-    end
-    return open(f, filename, mode, compression)
-end
-
 const MATH_OPT_FORMATS = Union{
     CBF.InnerModel, LP.InnerModel, MOF.Model, MPS.InnerModel
 }
 
-function MOI.write_to_file(model::MATH_OPT_FORMATS, filename::String; compression::AbstractCompressionScheme=AutomaticCompressionDetection())
-    gzip_open(filename, "w", compression=compression) do io
+function MOI.write_to_file(model::MATH_OPT_FORMATS, filename::String; compression::AbstractCompressionScheme=AutomaticCompression())
+    compression = _automatic_compression(filename, compression)
+    _compressed_open(filename, "w", compression) do io
         MOI.write_to_file(model, io)
     end
 end
 
-function MOI.read_from_file(model::MATH_OPT_FORMATS, filename::String; compression::AbstractCompressionScheme=AutomaticCompressionDetection())
-    gzip_open(filename, "r", compression=compression) do io
+function MOI.read_from_file(model::MATH_OPT_FORMATS, filename::String; compression::AbstractCompressionScheme=AutomaticCompression())
+    compression = _automatic_compression(filename, compression)
+    _compressed_open(filename, "r", compression) do io
         MOI.read_from_file(model, io)
     end
 end

--- a/src/MathOptFormat.jl
+++ b/src/MathOptFormat.jl
@@ -191,9 +191,9 @@ end
 Create a MOI model by reading `filename`. Type of the returned model depends on
 the extension of `filename`.
 """
-function read_from_file(filename::String)
+function read_from_file(filename::String; compression::AbstractCompressionScheme=AutomaticCompression())
     model = _filename_to_model(filename)
-    MOI.read_from_file(model, filename)
+    MOI.read_from_file(model, filename, compression=compression)
     return model
 end
 

--- a/src/MathOptFormat.jl
+++ b/src/MathOptFormat.jl
@@ -4,7 +4,7 @@ import MathOptInterface
 const MOI = MathOptInterface
 
 import CodecBzip2
-import CodecXz
+# import CodecXz
 import CodecZlib
 
 include("compression.jl")

--- a/src/compression.jl
+++ b/src/compression.jl
@@ -47,18 +47,18 @@ function _compressed_open(
     end
 end
 
-struct Xz <: AbstractCompressionScheme end
-function _compressed_open(
-    f::Function, filename::String, mode::String, ::Xz
-)
-    return if mode == "w"
-        Base.open(f, CodecXz.XzDecompressorStream, filename, mode)
-    elseif mode == "r"
-        Base.open(f, CodecXz.XzCompressorStream, filename, mode)
-    else
-        error_mode(mode)
-    end
-end
+# struct Xz <: AbstractCompressionScheme end
+# function _compressed_open(
+#     f::Function, filename::String, mode::String, ::Xz
+# )
+#     return if mode == "w"
+#         Base.open(f, CodecXz.XzDecompressorStream, filename, mode)
+#     elseif mode == "r"
+#         Base.open(f, CodecXz.XzCompressorStream, filename, mode)
+#     else
+#         error_mode(mode)
+#     end
+# end
 
 function _automatic_compression(filename::String, compression::AbstractCompressionScheme)
     if compression == AutomaticCompression()
@@ -72,8 +72,8 @@ function _filename_to_compression(filename::String)
         return Bzip2()
     elseif endswith(filename, ".gz")
         return Gzip()
-    elseif endswith(filename, ".xz")
-        return Xz()
+    # elseif endswith(filename, ".xz")
+    #     return Xz()
     else
         return NoCompression()
     end

--- a/src/compression.jl
+++ b/src/compression.jl
@@ -1,0 +1,48 @@
+function error_mode(mode::String)
+    throw(ArgumentError("For dealing with compressed data, mode must be \"r\" or \"w\"; $mode given"))
+end
+
+abstract type AbstractCompressionScheme end
+
+struct NoCompression <: AbstractCompressionScheme end
+function open(
+    f::Function, filename::String, mode::String, ::NoCompression
+)
+    return open(f, filename, mode)
+end
+
+struct Gzip <: AbstractCompressionScheme end
+function open(
+    f::Function, filename::String, mode::String, ::Gzip
+)
+    return if mode == "w"
+        open(f, CodecZlib.GzipCompressorStream, filename, "w")
+    elseif mode == "r"
+        open(f, CodecZlib.GzipDecompressorStream, filename, "w")
+    end
+    error_mode(mode)
+end
+
+struct Bzip2 <: AbstractCompressionScheme end
+function open(
+    f::Function, filename::String, mode::String, ::Bzip2
+)
+    return if mode == "w"
+        open(f, CodecBzip2.Bzip2CompressorStream, filename, "w")
+    elseif mode == "r"
+        open(f, CodecBzip2.Bzip2DecompressorStream, filename, "w")
+    end
+    error_mode(mode)
+end
+
+struct Xz <: AbstractCompressionScheme end
+function open(
+    f::Function, filename::String, mode::String, ::Xz
+)
+    return if mode == "w"
+        open(f, CodecXz.XzDecompressorStream, filename, "w")
+    elseif mode == "r"
+        open(f, CodecXz.XzCompressorStream, filename, "w")
+    end
+    error_mode(mode)
+end

--- a/src/compression.jl
+++ b/src/compression.jl
@@ -2,6 +2,13 @@ function error_mode(mode::String)
     throw(ArgumentError("For dealing with compressed data, mode must be \"r\" or \"w\"; $mode given"))
 end
 
+"""
+    abstract type AbstractCompressionScheme end
+
+Base type to implement a new compression scheme for MathOptFormat. To do so,
+create a concrete subtype (e.g., named after the compression scheme) and
+implement `open(f::Function, filename::String, mode::String, ::YourScheme)`. 
+"""
 abstract type AbstractCompressionScheme end
 
 struct AutomaticCompressionDetection <: AbstractCompressionScheme end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,25 +29,14 @@ const MOIU = MOI.Utilities
 
     @testset "Calling MOF.open" begin
         for cs in [MathOptFormat.Bzip2(), MathOptFormat.Gzip(), MathOptFormat.Xz()]
-            @test_throws ArgumentError MathOptFormat.open((x) -> nothing,
+            @test_throws ArgumentError MathOptFormat._compressed_open((x) -> nothing,
                                                           "dummy.gz", "a", cs)
-            @test_throws ArgumentError MathOptFormat.open((x) -> nothing,
+            @test_throws ArgumentError MathOptFormat._compressed_open((x) -> nothing,
                                                           "dummy.gz", "r+", cs)
-            @test_throws ArgumentError MathOptFormat.open((x) -> nothing,
+            @test_throws ArgumentError MathOptFormat._compressed_open((x) -> nothing,
                                                           "dummy.gz", "w+", cs)
-            @test_throws ArgumentError MathOptFormat.open((x) -> nothing,
+            @test_throws ArgumentError MathOptFormat._compressed_open((x) -> nothing,
                                                           "dummy.gz", "a+", cs)
         end
-    end
-
-    @testset "Calling gzip_open" begin
-        @test_throws ArgumentError MathOptFormat.gzip_open((x) -> nothing,
-                                                           "dummy.gz", "a")
-        @test_throws ArgumentError MathOptFormat.gzip_open((x) -> nothing,
-                                                           "dummy.gz", "r+")
-        @test_throws ArgumentError MathOptFormat.gzip_open((x) -> nothing,
-                                                           "dummy.gz", "w+")
-        @test_throws ArgumentError MathOptFormat.gzip_open((x) -> nothing,
-                                                           "dummy.gz", "a+")
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,7 +28,7 @@ const MOIU = MOI.Utilities
     end
 
     @testset "Calling MOF._compressed_open" begin
-        for cs in [MathOptFormat.Bzip2(), MathOptFormat.Gzip(), MathOptFormat.Xz()]
+        for cs in [MathOptFormat.Bzip2(), MathOptFormat.Gzip()] # MathOptFormat.Xz()
             @test_throws ArgumentError MathOptFormat._compressed_open((x) -> nothing,
                                                           "dummy.gz", "a", cs)
             @test_throws ArgumentError MathOptFormat._compressed_open((x) -> nothing,
@@ -46,14 +46,14 @@ const MOIU = MOI.Utilities
 
         @testset "Automatic detection from extension" begin
             MOI.write_to_file(m, file_to_read * ".garbage")
-            for ext in ["", ".bz2", ".gz", ".xz"]
+            for ext in ["", ".bz2", ".gz"] # ".xz"
                 MOI.write_to_file(m, file_to_read * ext)
                 MathOptFormat.read_from_file(file_to_read * ext)
             end
 
             # Clean up
             sleep(1.0)  # Allow time for unlink to happen.
-            for ext in ["", ".garbage", ".bz2", ".gz", ".xz"]
+            for ext in ["", ".garbage", ".bz2", ".gz"] # ".xz"
                 rm(file_to_read * ext, force = true)
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,7 +27,7 @@ const MOIU = MOI.Utilities
         end
     end
 
-    @testset "Calling MOF.open" begin
+    @testset "Calling MOF._compressed_open" begin
         for cs in [MathOptFormat.Bzip2(), MathOptFormat.Gzip(), MathOptFormat.Xz()]
             @test_throws ArgumentError MathOptFormat._compressed_open((x) -> nothing,
                                                           "dummy.gz", "a", cs)
@@ -37,6 +37,25 @@ const MOIU = MOI.Utilities
                                                           "dummy.gz", "w+", cs)
             @test_throws ArgumentError MathOptFormat._compressed_open((x) -> nothing,
                                                           "dummy.gz", "a+", cs)
+        end
+    end
+
+    @testset "Provided compression schemes" begin
+        file_to_read = joinpath(@__DIR__, "MPS", "free_integer.mps")
+        m = MathOptFormat.read_from_file(file_to_read)
+
+        @testset "Automatic detection from extension" begin
+            MOI.write_to_file(m, file_to_read * ".garbage")
+            for ext in ["", ".bz2", ".gz", ".xz"]
+                MOI.write_to_file(m, file_to_read * ext)
+                MathOptFormat.read_from_file(file_to_read * ext)
+            end
+
+            # Clean up
+            sleep(1.0)  # Allow time for unlink to happen.
+            for ext in ["", ".garbage", ".bz2", ".gz", ".xz"]
+                rm(file_to_read * ext, force = true)
+            end
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,19 @@ const MOIU = MOI.Utilities
         end
     end
 
+    @testset "Calling MOF.open" begin
+        for cs in [MathOptFormat.Bzip2(), MathOptFormat.Gzip(), MathOptFormat.Xz()]
+            @test_throws ArgumentError MathOptFormat.open((x) -> nothing,
+                                                          "dummy.gz", "a", cs)
+            @test_throws ArgumentError MathOptFormat.open((x) -> nothing,
+                                                          "dummy.gz", "r+", cs)
+            @test_throws ArgumentError MathOptFormat.open((x) -> nothing,
+                                                          "dummy.gz", "w+", cs)
+            @test_throws ArgumentError MathOptFormat.open((x) -> nothing,
+                                                          "dummy.gz", "a+", cs)
+        end
+    end
+
     @testset "Calling gzip_open" begin
         @test_throws ArgumentError MathOptFormat.gzip_open((x) -> nothing,
                                                            "dummy.gz", "a")
@@ -36,6 +49,5 @@ const MOIU = MOI.Utilities
                                                            "dummy.gz", "w+")
         @test_throws ArgumentError MathOptFormat.gzip_open((x) -> nothing,
                                                            "dummy.gz", "a+")
-        
     end
 end


### PR DESCRIPTION
Following https://github.com/JuliaOpt/JuMP.jl/pull/1982, here is the implementation of two other compression formats (BZIP2 and XZ). While I was at it, I also refactored a bit the common functions (in the hope that adding new compression formats and new export formats will be easier, the changes to be done being centralised). 

For now, I did not add tests, as I'm not sure which ones I should add (currently, it seems compression is handled within each file format, but I think just testing one of them should be enough -- e.g., just LP, as nothing is really dependent on the file format). 