### PR TITLE
[CBF] Remove support for SingleVariable constraints except Integer

### DIFF
--- a/src/CBF/CBF.jl
+++ b/src/CBF/CBF.jl
@@ -18,6 +18,16 @@ MOI.Utilities.@model(InnerModel,
     (MOI.VectorOfVariables,),
     (MOI.VectorAffineFunction,)
 )
+function MOI.supports_constraint(
+    ::InnerModel{T}, ::Type{MOI.SingleVariable},
+    ::Type{<:MOI.Utilities.SUPPORTED_VARIABLE_SCALAR_SETS{T}}) where T
+
+    return false
+end
+function MOI.supports_constraint(
+    ::InnerModel, ::Type{MOI.SingleVariable}, ::Type{MOI.Integer})
+    return true
+end
 
 struct Options end
 

--- a/test/CBF/CBF.jl
+++ b/test/CBF/CBF.jl
@@ -76,6 +76,27 @@ end
     @test !MOI.is_empty(MathOptFormat.read_from_file(file_to_read * ".gz"))
 end
 
+@testset "Support errors" begin
+    @testset "$set variable bound" for set in [
+            MOI.EqualTo(1.0),
+            MOI.LessThan(1.0),
+            MOI.GreaterThan(1.0),
+            MOI.Interval(1.0, 2.0),
+            MOI.Semiinteger(1.0, 2.0),
+            MOI.Semicontinuous(1.0, 2.0),
+            MOI.ZeroOne()
+        ]
+        model_string = """
+        variables: x
+        minobjective: x
+        c: x in $set
+        """
+        model = CBF.Model()
+        err = MOI.UnsupportedConstraint{MOI.SingleVariable, typeof(set)}
+        @test_throws err MOIU.loadfromstring!(model, model_string)
+    end
+end
+
 @testset "Read errors" begin
     @testset "Non-empty model" begin
         model = CBF.Model()


### PR DESCRIPTION
These are not supported by the CBF format and should be bridged.
For Semiinteger and Semicontinuous, this would require https://github.com/JuliaOpt/MathOptInterface.jl/issues/897
For ZeroOne, this would require https://github.com/JuliaOpt/MathOptInterface.jl/issues/704

Closes https://github.com/odow/MathOptFormat.jl/issues/89