### PR TITLE
Simplify how name sanitization is done

### DIFF
--- a/src/LP/LP.jl
+++ b/src/LP/LP.jl
@@ -19,13 +19,10 @@ MOI.Utilities.@model(InnerModel,
 struct Options
     maximum_length::Int
     warn::Bool
-    warn_once::Bool
-    warned_start::Set{Char}
-    warned_illegal::Set{Char}
 end
 
 function get_options(m::InnerModel)
-    default_options = Options(255, false, false, Set{Char}(), Set{Char}())
+    default_options = Options(255, false)
     return get(m.ext, :LP_OPTIONS, default_options)
 end
 
@@ -40,16 +37,12 @@ Keyword arguments are:
    lp_solve 5.0 allows only 16 characters, while CPLEX 12.5+ allow 255.
 
  - `warn::Bool=false`: print a warning when variables or constraints are renamed.
-
- - `warn_once::Bool=false`: print a warning when variables or constraints are
-   renamed, but only once per kind of replacement (e.g., once per illegal
-   character).
 """
 function Model(;
-    maximum_length::Int = 255, warn::Bool = false, warn_once::Bool = false
+    maximum_length::Int = 255, warn::Bool = false
 )
     model = InnerModel{Float64}()
-    options = Options(maximum_length, warn, warn_once, Set{Char}(), Set{Char}())
+    options = Options(maximum_length, warn)
     model.ext[:LP_OPTIONS] = options
     return model
 end
@@ -65,55 +58,25 @@ end
 #
 # ==============================================================================
 
-
 const START_REG = r"^([\.0-9eE])"
 const NAME_REG = r"([^a-zA-Z0-9\!\"\#\$\%\&\(\)\/\,\.\;\?\@\_\`\'\{\}\|\~])"
 
-function sanitized_name(name::String, options::Options)
-    m = match(START_REG, name)
-    if m !== nothing
-        plural = length(m.match) > 1
-
-        if options.warn || (options.warn_once && !(m.match[1] in options.warned_start))
-            @warn("Name $(name) cannot start with a period, a number, e, or E. " *
-                  "Prepending an underscore to name.")
-            push!(options.warned_start, m.match[1])
-        end
-
-        return sanitized_name("_" * name, options)
-    end
-
-    m = match(NAME_REG, name)
-    if m !== nothing
-        plural = length(m.match) > 1
-
-        if options.warn || (options.warn_once && !(m.match[1] in options.warned_illegal))
-            @warn("Name $(name) contains $(ifelse(plural, "", "an "))" *
-                  "illegal character$(ifelse(plural, "s", "")): " *
-                  "\"$(m.match)\". Removing the offending " *
-                  "character$(ifelse(plural, "s", "")) from name.")
-            push!(options.warned_illegal, m.match[1])
-        end
-
-        return sanitized_name(replace(name, NAME_REG => s"_"), options)
-    end
-
-    # Truncate at the end to fit as many characters as possible.
-    if length(name) > options.maximum_length
-        @warn("Name $(name) too long (length: $(length(name)); " *
-              "maximum: $(options.maximum_length)). Truncating.")
-        return sanitized_name(String(name[1:options.maximum_length]), options)
-    end
-
-    return name
-end
-
-function write_function(io::IO, model::InnerModel, func::MOI.SingleVariable, sanitized_names::Dict{MOI.VariableIndex, String})
-    print(io, sanitized_names[func.variable])
+function write_function(
+    io::IO,
+    model::InnerModel,
+    func::MOI.SingleVariable,
+    variable_names::Dict{MOI.VariableIndex, String}
+)
+    print(io, variable_names[func.variable])
     return
 end
 
-function write_function(io::IO, model::InnerModel, func::MOI.ScalarAffineFunction{Float64}, sanitized_names::Dict{MOI.VariableIndex, String})
+function write_function(
+    io::IO,
+    model::InnerModel,
+    func::MOI.ScalarAffineFunction{Float64},
+    variable_names::Dict{MOI.VariableIndex, String}
+)
     is_first_item = true
     if !(func.constant ≈ 0.0)
         Base.Grisu.print_shortest(io, func.constant)
@@ -129,7 +92,7 @@ function write_function(io::IO, model::InnerModel, func::MOI.ScalarAffineFunctio
                 Base.Grisu.print_shortest(io, abs(term.coefficient))
             end
 
-            print(io, " ", sanitized_names[term.variable_index])
+            print(io, " ", variable_names[term.variable_index])
         end
     end
     return
@@ -171,14 +134,20 @@ end
 
 write_constraint_prefix(io::IO, set) = nothing
 
-function write_constraint(io::IO, model::InnerModel, index, sanitized_names::Dict{MOI.VariableIndex, String}; write_name::Bool = true)
+function write_constraint(
+    io::IO,
+    model::InnerModel,
+    index::MOI.ConstraintIndex,
+    variable_names::Dict{MOI.VariableIndex, String};
+    write_name::Bool = true
+)
     func = MOI.get(model, MOI.ConstraintFunction(), index)
     set = MOI.get(model, MOI.ConstraintSet(), index)
     if write_name
         print(io, MOI.get(model, MOI.ConstraintName(), index), ": ")
     end
     write_constraint_prefix(io, set)
-    write_function(io, model, func, sanitized_names)
+    write_function(io, model, func, variable_names)
     write_constraint_suffix(io, set)
 end
 
@@ -196,75 +165,74 @@ function write_sense(io::IO, model::InnerModel)
     return
 end
 
-function write_objective(io::IO, model::InnerModel, sanitized_names::Dict{MOI.VariableIndex, String})
+function write_objective(
+    io::IO, model::InnerModel, variable_names::Dict{MOI.VariableIndex, String}
+)
     print(io, "obj: ")
     obj_func_type = MOI.get(model, MOI.ObjectiveFunctionType())
     obj_func = MOI.get(model, MOI.ObjectiveFunction{obj_func_type}())
-    write_function(io, model, obj_func, sanitized_names)
+    write_function(io, model, obj_func, variable_names)
     println(io)
     return
 end
 
 function MOI.write_to_file(model::InnerModel, io::IO)
     options = get_options(model)
-    max_length = options.maximum_length
-    # Ensure each variable has a unique name that does not infringe LP constraints.
-    MathOptFormat.create_unique_names(model, warn = options.warn)
-    sanitized_names = Dict{MOI.VariableIndex, String}()
-    sanitized_names_set = Set{String}()
-    for v in MOI.get(model, MOI.ListOfVariableIndices())
-        proposed_sanitized_name = sanitized_name(MOI.get(model, MOI.VariableName(), v), options)
-        # In case of duplicate names after sanitization, add a number at the end.
-        if proposed_sanitized_name in sanitized_names_set
-            # If the name is already too long, make some space for the suffix.
-            if length(proposed_sanitized_name) >= max_length
-                proposed_sanitized_name = String(proposed_sanitized_name[1:max_length - 2])
-            end
-            i = 1
-            while proposed_sanitized_name * '_' * string(i) in sanitized_names_set
-                i += 1
-
-                # If the maximum length constraint would be broken with the *next* i,
-                # truncate a bit more the proposed_sanitized_name.
-                if length(proposed_sanitized_name * '_' * string(i)) > max_length
-                    proposed_sanitized_name = String(proposed_sanitized_name[1:length(proposed_sanitized_name) - 1])
-                end
-            end
-            proposed_sanitized_name *= '_' * string(i)
-        end
-        push!(sanitized_names_set, proposed_sanitized_name)
-        sanitized_names[v] = proposed_sanitized_name
-    end
-
+    MathOptFormat.create_unique_names(
+        model,
+        warn = options.warn,
+        replacements = [
+            s -> match(START_REG, s) !== nothing ? "_" * s : s,
+            s -> replace(s, NAME_REG => "_"),
+            s -> s[1:min(length(s), options.maximum_length)]
+        ]
+    )
+    variable_names = Dict{MOI.VariableIndex, String}(
+        index => MOI.get(model, MOI.VariableName(), index)
+        for index in MOI.get(model, MOI.ListOfVariableIndices())
+    )
     write_sense(io, model)
-    write_objective(io, model, sanitized_names)
+    write_objective(io, model, variable_names)
     println(io, "subject to")
     for S in SCALAR_SETS
-        for index in MOI.get(model, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Float64}, S}())
-            write_constraint(io, model, index, sanitized_names; write_name = true)
+        for index in MOI.get(
+            model,
+            MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Float64}, S}()
+        )
+            write_constraint(
+                io, model, index, variable_names; write_name = true
+            )
         end
     end
-
     println(io, "Bounds")
     for S in SCALAR_SETS
-        for index in MOI.get(model, MOI.ListOfConstraintIndices{MOI.SingleVariable, S}())
-            write_constraint(io, model, index, sanitized_names; write_name = false)
+        for index in MOI.get(
+            model,
+            MOI.ListOfConstraintIndices{MOI.SingleVariable, S}()
+        )
+            write_constraint(
+                io, model, index, variable_names; write_name = false
+            )
         end
     end
-
     for (S, str_S) in [(MOI.Integer, "General"), (MOI.ZeroOne, "Binary")]
-        indices = MOI.get(model, MOI.ListOfConstraintIndices{MOI.SingleVariable, S}())
+        indices = MOI.get(
+            model, MOI.ListOfConstraintIndices{MOI.SingleVariable, S}()
+        )
         if length(indices) > 0
             println(io, str_S)
             for index in indices
-                write_function(io, model, MOI.get(model, MOI.ConstraintFunction(), index), sanitized_names)
+                write_function(
+                    io,
+                    model,
+                    MOI.get(model, MOI.ConstraintFunction(), index),
+                    variable_names
+                )
                 println(io)
             end
         end
     end
-
     println(io, "End")
-
     return
 end
 

--- a/src/MPS/MPS.jl
+++ b/src/MPS/MPS.jl
@@ -53,7 +53,9 @@ end
 function MOI.write_to_file(model::InnerModel, io::IO)
     options = get_options(model)
     MathOptFormat.create_unique_names(
-        model, warn = options.warn, replacements = [' ' => '_']
+        model;
+        warn = options.warn,
+        replacements = Function[s -> replace(s, ' ' => '_')]
     )
     write_model_name(io, model)
     write_rows(io, model)

--- a/test/LP/LP.jl
+++ b/test/LP/LP.jl
@@ -45,90 +45,63 @@ const LP_TEST_FILE = "test.lp"
         MOI.empty!(model)
         @test MOI.is_empty(model)
     end
-
-    @testset "Name sanitisation" begin
-        @testset "sanitized_name" begin
-            max_length = 15
-            o = LP.Options(max_length, true, false, Set{Char}(), Set{Char}())
-
-            @test LP.sanitized_name("x", o) == "x"
-            @test LP.sanitized_name(repeat("x", max_length), o) == repeat("x", max_length)
-
-            too_long = repeat("x", max_length + 1)
-            @test (@test_logs (:warn, "Name $(too_long) too long (length: $(length(too_long)); maximum: $(max_length)). Truncating.") LP.sanitized_name(too_long, o)) == repeat("x", max_length)
-
-            @test (@test_logs (:warn, "Name .x cannot start with a period, a number, e, or E. Prepending an underscore to name.") LP.sanitized_name(".x", o)) == "_.x"
-            @test (@test_logs (:warn, "Name 0x cannot start with a period, a number, e, or E. Prepending an underscore to name.") LP.sanitized_name("0x", o)) == "_0x"
-            @test (@test_logs (:warn, "Name Ex cannot start with a period, a number, e, or E. Prepending an underscore to name.") LP.sanitized_name("Ex", o)) == "_Ex"
-            @test (@test_logs (:warn, "Name ex cannot start with a period, a number, e, or E. Prepending an underscore to name.") LP.sanitized_name("ex", o)) == "_ex"
-
-            @test (@test_logs (:warn, "Name x*ds contains an illegal character: \"*\". Removing the offending character from name.") LP.sanitized_name("x*ds", o)) == "x_ds"
-            @test (@test_logs (:warn, "Name x^ contains an illegal character: \"^\". Removing the offending character from name.") LP.sanitized_name("x^", o)) == "x_"
-            @test (@test_logs (:warn, "Name x*ds[1] contains an illegal character: \"*\". Removing the offending character from name.") LP.sanitized_name("x*ds[1]", o)) == "x_ds_1_"
-            @test (@test_logs(
-                    (:warn, "Name Ex*ds[1] cannot start with a period, a number, e, or E. Prepending an underscore to name."),
-                    (:warn, "Name _Ex*ds[1] contains an illegal character: \"*\". Removing the offending character from name."),
-                    LP.sanitized_name("Ex*ds[1]", o))
-                ) == "_Ex_ds_1_"
+    @testset "Name sanitization" begin
+        @testset "Start name sanitisation" begin
+            for starting_letter in [".", "0", "E", "e"]
+                model = LP.Model()
+                MOI.Utilities.loadfromstring!(model, """
+                variables: x
+                minobjective: x
+                c1: 1.0 * x >= -1.0
+                """)
+                x = MOI.get(model, MOI.VariableIndex, "x")
+                MOI.set(model, MOI.VariableName(), x, starting_letter * "x")
+                c = MOI.get(model, MOI.ConstraintIndex, "c1")
+                MOI.set(model, MOI.ConstraintName(), c, starting_letter * "c1")
+                MOI.write_to_file(model, LP_TEST_FILE)
+                @test read(LP_TEST_FILE, String) ==
+                    "minimize\n" *
+                    "obj: _$(starting_letter)x\n" *
+                    "subject to\n" *
+                    "_$(starting_letter)c1: 1 _$(starting_letter)x >= -1\n" *
+                    "Bounds\n" *
+                    "End\n"
+            end
         end
-
-        @testset "Whole chain" begin
-            model = LP.Model(warn=true)
-            MOIU.loadfromstring!(model, """
-            variables: a
-            minobjective: a
-            c1: a >= -1.0
-            """)
-            MOI.set(model, MOI.VariableName(), MOI.get(model, MOI.ListOfVariableIndices())[1], "a[]")
-
-            @test_logs (:warn, "Name a[] contains an illegal character: \"[\". Removing the offending character from name.") MOI.write_to_file(model, LP_TEST_FILE)
+        @testset "Illegal character sanitisation" begin
+            for illegal_letter in ["[", "]", "*", "^"]
+                model = LP.Model()
+                MOI.Utilities.loadfromstring!(model, """
+                variables: x
+                minobjective: x
+                c1: 1.0 * x >= -1.0
+                """)
+                x = MOI.get(model, MOI.VariableIndex, "x")
+                MOI.set(model, MOI.VariableName(), x, "x$(illegal_letter)y")
+                c = MOI.get(model, MOI.ConstraintIndex, "c1")
+                MOI.set(model, MOI.ConstraintName(), c, "c$(illegal_letter)d")
+                MOI.write_to_file(model, LP_TEST_FILE)
+                @test read(LP_TEST_FILE, String) ==
+                    "minimize\n" *
+                    "obj: x_y\n" *
+                    "subject to\n" *
+                    "c_d: 1 x_y >= -1\n" *
+                    "Bounds\n" *
+                    "End\n"
+            end
         end
-
-        @testset "Warn multiple times" begin
-            model = LP.Model(warn=true)
-            MOIU.loadfromstring!(model, """
-            variables: a, b, c
-            minobjective: a + b + c
-            c1: a + b + c >= -1.0
-            """)
-            MOI.set(model, MOI.VariableName(), MOI.get(model, MOI.ListOfVariableIndices())[1], "a[]")
-            MOI.set(model, MOI.VariableName(), MOI.get(model, MOI.ListOfVariableIndices())[2], "b[]")
-            MOI.set(model, MOI.VariableName(), MOI.get(model, MOI.ListOfVariableIndices())[3], "c[]")
-
-            @test_logs(
-                (:warn, "Name a[] contains an illegal character: \"[\". Removing the offending character from name."),
-                (:warn, "Name b[] contains an illegal character: \"[\". Removing the offending character from name."),
-                (:warn, "Name c[] contains an illegal character: \"[\". Removing the offending character from name."),
-                MOI.write_to_file(model, LP_TEST_FILE))
-        end
-
-        @testset "Warn once" begin
-            model = LP.Model(warn_once=true)
-            MOIU.loadfromstring!(model, """
-            variables: a, b, c
-            minobjective: a + b + c
-            c1: a + b + c >= -1.0
-            """)
-            MOI.set(model, MOI.VariableName(), MOI.get(model, MOI.ListOfVariableIndices())[1], "a[]")
-            MOI.set(model, MOI.VariableName(), MOI.get(model, MOI.ListOfVariableIndices())[2], "b[]")
-            MOI.set(model, MOI.VariableName(), MOI.get(model, MOI.ListOfVariableIndices())[3], "c[]")
-
-            @test_logs (:warn, "Name a[] contains an illegal character: \"[\". Removing the offending character from name.") MOI.write_to_file(model, LP_TEST_FILE)
-        end
-
         @testset "Duplicate names after sanitization" begin
-            model = LP.Model(warn=true)
-            MOIU.loadfromstring!(model, """
+            model = LP.Model()
+            MOI.Utilities.loadfromstring!(model, """
             variables: a, b, c, d
             minobjective: a + b + c + d
             c1: a + b + c + d >= -1.0
             """)
-            MOI.set(model, MOI.VariableName(), MOI.get(model, MOI.ListOfVariableIndices())[1], "a[")
-            MOI.set(model, MOI.VariableName(), MOI.get(model, MOI.ListOfVariableIndices())[2], "a]")
-            MOI.set(model, MOI.VariableName(), MOI.get(model, MOI.ListOfVariableIndices())[3], "a*")
-            MOI.set(model, MOI.VariableName(), MOI.get(model, MOI.ListOfVariableIndices())[4], "a^")
-
-            @test_logs (:warn, "Name a[ contains an illegal character: \"[\". Removing the offending character from name.") (:warn, "Name a] contains an illegal character: \"]\". Removing the offending character from name.") (:warn, "Name a* contains an illegal character: \"*\". Removing the offending character from name.") (:warn, "Name a^ contains an illegal character: \"^\". Removing the offending character from name.") MOI.write_to_file(model, LP_TEST_FILE)
+            variables = MOI.get(model, MOI.ListOfVariableIndices())
+            MOI.set.(
+                model, MOI.VariableName(), variables, ["a[", "a]", "a*", "a^"]
+            )
+            MOI.write_to_file(model, LP_TEST_FILE)
             @test read(LP_TEST_FILE, String) ==
                 "minimize\n" *
                 "obj: 1 a_ + 1 a__1 + 1 a__2 + 1 a__3\n" *
@@ -137,102 +110,41 @@ const LP_TEST_FILE = "test.lp"
                 "Bounds\n" *
                 "End\n"
         end
-
-        @testset "Too long duplicate names after sanitization" begin
-            max_length = 15
-
-            model = LP.Model(maximum_length=max_length, warn=true)
-            MOIU.loadfromstring!(model, """
-            variables: a, b, c, d
-            minobjective: a + b + c + d
-            c1: a + b + c + d >= -1.0
-            """)
-            MOI.set(model, MOI.VariableName(), MOI.get(model, MOI.ListOfVariableIndices())[1], "a[")
-            MOI.set(model, MOI.VariableName(), MOI.get(model, MOI.ListOfVariableIndices())[2], "a]")
-            MOI.set(model, MOI.VariableName(), MOI.get(model, MOI.ListOfVariableIndices())[3], "a*" * repeat("x", max_length + 1))
-            MOI.set(model, MOI.VariableName(), MOI.get(model, MOI.ListOfVariableIndices())[4], "a^" * repeat("x", max_length + 1))
-
-            @test_logs(
-                (:warn, "Name a[ contains an illegal character: \"[\". Removing the offending character from name."),
-                (:warn, "Name a] contains an illegal character: \"]\". Removing the offending character from name."),
-                (:warn, "Name a*$(repeat("x", max_length + 1)) contains an illegal character: \"*\". Removing the offending character from name."),
-                (:warn, "Name a_$(repeat("x", max_length + 1)) too long (length: $(2 + max_length + 1); maximum: $(max_length)). Truncating."),
-                (:warn, "Name a^$(repeat("x", max_length + 1)) contains an illegal character: \"^\". Removing the offending character from name."),
-                (:warn, "Name a_$(repeat("x", max_length + 1)) too long (length: $(2 + max_length + 1); maximum: $(max_length)). Truncating."),
-                MOI.write_to_file(model, LP_TEST_FILE))
+        @testset "Length sanitisation" begin
+            model = LP.Model(maximum_length = 3)
+            x = MOI.add_variable(model)
+            MOI.set(model, MOI.VariableName(), x, "abcdefg")
+            MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+            MOI.set(
+                model,
+                MOI.ObjectiveFunction{MOI.SingleVariable}(),
+                MOI.SingleVariable(x)
+            )
+            MOI.write_to_file(model, LP_TEST_FILE)
             @test read(LP_TEST_FILE, String) ==
                 "minimize\n" *
-                "obj: 1 a_ + 1 a__1 + 1 a_$(repeat("x", max_length - 2)) + 1 a_$(repeat("x", max_length - 4))_1\n" *
+                "obj: abc\n" *
                 "subject to\n" *
-                "c1: 1 a_ + 1 a__1 + 1 a_$(repeat("x", max_length - 2)) + 1 a_$(repeat("x", max_length - 4))_1 >= -1\n" *
                 "Bounds\n" *
                 "End\n"
         end
-
-        @testset "Many too long duplicate names after sanitization" begin
-            max_length = 6
-
-            model = LP.Model(maximum_length=max_length, warn=true)
-            MOIU.loadfromstring!(model, """
-            variables: a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r
-            minobjective: a + b + c + d + e + f + g + h + i + j + k + l + m + n + o + p + q + r
-            c1: a + b + c + d + e + f + g + h + i + j + k + l + m + n + o + p + q + r >= -1.0
+        @testset "Too long duplicate names after sanitization" begin
+            model = LP.Model(maximum_length=3)
+            MOI.Utilities.loadfromstring!(model, """
+            variables: abcd, abce
+            minobjective: abcd + abce
+            c1: abcd + abce >= -1.0
             """)
-            for i in 1:18
-                MOI.set(model, MOI.VariableName(), MOI.get(model, MOI.ListOfVariableIndices())[i], repeat("x", max_length + 1))
-            end
-
-            @test_logs(
-                (:warn, "Duplicate name xxxxxxx detected for variable MathOptInterface.VariableIndex(2). Renamed to xxxxxxx_1."),
-                (:warn, "Duplicate name xxxxxxx detected for variable MathOptInterface.VariableIndex(3). Renamed to xxxxxxx_2."),
-                (:warn, "Duplicate name xxxxxxx detected for variable MathOptInterface.VariableIndex(4). Renamed to xxxxxxx_3."),
-                (:warn, "Duplicate name xxxxxxx detected for variable MathOptInterface.VariableIndex(5). Renamed to xxxxxxx_4."),
-                (:warn, "Duplicate name xxxxxxx detected for variable MathOptInterface.VariableIndex(6). Renamed to xxxxxxx_5."),
-                (:warn, "Duplicate name xxxxxxx detected for variable MathOptInterface.VariableIndex(7). Renamed to xxxxxxx_6."),
-                (:warn, "Duplicate name xxxxxxx detected for variable MathOptInterface.VariableIndex(8). Renamed to xxxxxxx_7."),
-                (:warn, "Duplicate name xxxxxxx detected for variable MathOptInterface.VariableIndex(9). Renamed to xxxxxxx_8."),
-                (:warn, "Duplicate name xxxxxxx detected for variable MathOptInterface.VariableIndex(10). Renamed to xxxxxxx_9."),
-                (:warn, "Duplicate name xxxxxxx detected for variable MathOptInterface.VariableIndex(11). Renamed to xxxxxxx_10."),
-                (:warn, "Duplicate name xxxxxxx detected for variable MathOptInterface.VariableIndex(12). Renamed to xxxxxxx_11."),
-                (:warn, "Duplicate name xxxxxxx detected for variable MathOptInterface.VariableIndex(13). Renamed to xxxxxxx_12."),
-                (:warn, "Duplicate name xxxxxxx detected for variable MathOptInterface.VariableIndex(14). Renamed to xxxxxxx_13."),
-                (:warn, "Duplicate name xxxxxxx detected for variable MathOptInterface.VariableIndex(15). Renamed to xxxxxxx_14."),
-                (:warn, "Duplicate name xxxxxxx detected for variable MathOptInterface.VariableIndex(16). Renamed to xxxxxxx_15."),
-                (:warn, "Duplicate name xxxxxxx detected for variable MathOptInterface.VariableIndex(17). Renamed to xxxxxxx_16."),
-                (:warn, "Duplicate name xxxxxxx detected for variable MathOptInterface.VariableIndex(18). Renamed to xxxxxxx_17."),
-                (:warn, "Name $(repeat("x", max_length + 1)) too long (length: $(1 + max_length); maximum: $(max_length)). Truncating."),
-                (:warn, "Name $(repeat("x", max_length + 1))_1 too long (length: $(3 + max_length); maximum: $(max_length)). Truncating."),
-                (:warn, "Name $(repeat("x", max_length + 1))_2 too long (length: $(3 + max_length); maximum: $(max_length)). Truncating."),
-                (:warn, "Name $(repeat("x", max_length + 1))_3 too long (length: $(3 + max_length); maximum: $(max_length)). Truncating."),
-                (:warn, "Name $(repeat("x", max_length + 1))_4 too long (length: $(3 + max_length); maximum: $(max_length)). Truncating."),
-                (:warn, "Name $(repeat("x", max_length + 1))_5 too long (length: $(3 + max_length); maximum: $(max_length)). Truncating."),
-                (:warn, "Name $(repeat("x", max_length + 1))_6 too long (length: $(3 + max_length); maximum: $(max_length)). Truncating."),
-                (:warn, "Name $(repeat("x", max_length + 1))_7 too long (length: $(3 + max_length); maximum: $(max_length)). Truncating."),
-                (:warn, "Name $(repeat("x", max_length + 1))_8 too long (length: $(3 + max_length); maximum: $(max_length)). Truncating."),
-                (:warn, "Name $(repeat("x", max_length + 1))_9 too long (length: $(3 + max_length); maximum: $(max_length)). Truncating."),
-                (:warn, "Name $(repeat("x", max_length + 1))_10 too long (length: $(4 + max_length); maximum: $(max_length)). Truncating."),
-                (:warn, "Name $(repeat("x", max_length + 1))_11 too long (length: $(4 + max_length); maximum: $(max_length)). Truncating."),
-                (:warn, "Name $(repeat("x", max_length + 1))_12 too long (length: $(4 + max_length); maximum: $(max_length)). Truncating."),
-                (:warn, "Name $(repeat("x", max_length + 1))_13 too long (length: $(4 + max_length); maximum: $(max_length)). Truncating."),
-                (:warn, "Name $(repeat("x", max_length + 1))_14 too long (length: $(4 + max_length); maximum: $(max_length)). Truncating."),
-                (:warn, "Name $(repeat("x", max_length + 1))_15 too long (length: $(4 + max_length); maximum: $(max_length)). Truncating."),
-                (:warn, "Name $(repeat("x", max_length + 1))_16 too long (length: $(4 + max_length); maximum: $(max_length)). Truncating."),
-                (:warn, "Name $(repeat("x", max_length + 1))_17 too long (length: $(4 + max_length); maximum: $(max_length)). Truncating."),
-                MOI.write_to_file(model, LP_TEST_FILE))
-
-            expr = "1 " * repeat("x", max_length) * " + " *
-                join(["1 " * repeat("x", max_length - 2) * "_" * string(i) for i in 1:9], " + ") * " + " *
-                join(["1 " * repeat("x", max_length - 3) * "_" * string(i) for i in 10:17], " + ")
+            MOI.write_to_file(model, LP_TEST_FILE)
             @test read(LP_TEST_FILE, String) ==
                 "minimize\n" *
-                "obj: $(expr)\n" *
+                "obj: 1 abc + 1 abc_1\n" *
                 "subject to\n" *
-                "c1: $(expr) >= -1\n" *
+                "c1: 1 abc + 1 abc_1 >= -1\n" *
                 "Bounds\n" *
                 "End\n"
         end
     end
-
     @testset "other features" begin
         model = LP.Model()
         MOIU.loadfromstring!(model, """


### PR DESCRIPTION
Closes #82 

There is one annoying thing I've left un-done: what to do with LP names if they exceed the name length after normalization. I've opted to ignore them, since I don't see this being a practical problem. We can re-visit in the future if necessary.

cc @dourouc05 