### PR TITLE
DNMY: Add support for the MOP file format

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,145 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[BenchmarkTools]]
+deps = ["JSON", "Printf", "Statistics"]
+git-tree-sha1 = "90b73db83791c5f83155016dd1cc1f684d4e1361"
+uuid = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+version = "0.4.3"
+
+[[BinaryProvider]]
+deps = ["Libdl", "SHA"]
+git-tree-sha1 = "5b08ed6036d9d3f0ee6369410b830f8873d4024c"
+uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
+version = "0.5.8"
+
+[[CodecBzip2]]
+deps = ["BinaryProvider", "Libdl", "TranscodingStreams"]
+git-tree-sha1 = "5db086e510c11b4c87d05067627eadb2dc079995"
+uuid = "523fee87-0ab8-5b00-afb7-3ecf72e48cfd"
+version = "0.6.0"
+
+[[CodecZlib]]
+deps = ["BinaryProvider", "Libdl", "TranscodingStreams"]
+git-tree-sha1 = "05916673a2627dd91b4969ff8ba6941bc85a960e"
+uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
+version = "0.6.0"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[HTTP]]
+deps = ["Base64", "Dates", "IniFile", "MbedTLS", "Sockets"]
+git-tree-sha1 = "5c49dab19938b119fe204fd7d7e8e174f4e9c68b"
+uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+version = "0.8.8"
+
+[[IniFile]]
+deps = ["Test"]
+git-tree-sha1 = "098e4d2c533924c921f9f9847274f2ad89e018b8"
+uuid = "83e8ac13-25f8-5344-8a64-a9f2b223428f"
+version = "0.5.0"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[JSON]]
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "b34d7cef7b337321e97d22242c3c2b91f476748e"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.0"
+
+[[JSONSchema]]
+deps = ["HTTP", "JSON", "Test"]
+git-tree-sha1 = "6f80c4ea9ccf648766380b28b63efd1050dee940"
+uuid = "7d188eb4-7ad8-530c-ae41-71a32a6d4692"
+version = "0.1.1"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[MathOptInterface]]
+deps = ["BenchmarkTools", "LinearAlgebra", "OrderedCollections", "SparseArrays", "Test", "Unicode"]
+git-tree-sha1 = "2cbf5d6dde94a85dd28ef702ef637079dc587728"
+repo-rev = "od/multi-objective"
+repo-url = "https://github.com/JuliaOpt/MathOptInterface.jl.git"
+uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+version = "0.9.7"
+
+[[MbedTLS]]
+deps = ["BinaryProvider", "Dates", "Distributed", "Libdl", "Random", "Sockets", "Test"]
+git-tree-sha1 = "2d94286a9c2f52c63a16146bb86fd6cdfbf677c6"
+uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
+version = "0.6.8"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[OrderedCollections]]
+deps = ["Random", "Serialization", "Test"]
+git-tree-sha1 = "c4c13474d23c60d20a67b217f1d7f22a40edf8f1"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.1.0"
+
+[[Parsers]]
+deps = ["Dates", "Test"]
+git-tree-sha1 = "0139ba59ce9bc680e2925aec5b7db79065d60556"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "0.3.10"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[TranscodingStreams]]
+deps = ["Random", "Test"]
+git-tree-sha1 = "7c53c35547de1c5b9d46a4797cf6d8253807108c"
+uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
+version = "0.9.5"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/src/CBF/CBF.jl
+++ b/src/CBF/CBF.jl
@@ -29,6 +29,17 @@ function MOI.supports_constraint(
     return true
 end
 
+function MOI.supports(
+    ::InnerModel,
+    ::MOI.ObjectiveFunction{<:Union{
+        MOI.VectorOfVariables,
+        MOI.VectorAffineFunction{Float64},
+        MOI.VectorQuadraticFunction{Float64}
+    }}
+)
+    return false
+end
+
 struct Options end
 
 get_options(m::InnerModel) = get(m.ext, :CBF_OPTIONS, Options())

--- a/src/LP/LP.jl
+++ b/src/LP/LP.jl
@@ -16,6 +16,18 @@ MOI.Utilities.@model(InnerModel,
     ()
 )
 
+function MOI.supports(
+    ::InnerModel,
+    ::MOI.ObjectiveFunction{<:Union{
+        MOI.ScalarQuadraticFunction{Float64},
+        MOI.VectorOfVariables,
+        MOI.VectorAffineFunction{Float64},
+        MOI.VectorQuadraticFunction{Float64}
+    }}
+)
+    return false
+end
+
 struct Options
     maximum_length::Int
     warn::Bool

--- a/src/MathOptFormat.jl
+++ b/src/MathOptFormat.jl
@@ -23,6 +23,7 @@ List of accepted export formats.
 - `FORMAT_CBF`: the Conic Benchmark format
 - `FORMAT_LP`: the LP file format
 - `FORMAT_MOF`: the MathOptFormat file format
+- `FORMAT_MOP`: the Multi-Objective Problem file format
 - `FORMAT_MPS`: the MPS file format
 - `FORMAT_SDPA`: the SemiDefinite Programming Algorithm format
 """
@@ -32,6 +33,7 @@ List of accepted export formats.
     FORMAT_CBF,
     FORMAT_LP,
     FORMAT_MOF,
+    FORMAT_MOP,
     FORMAT_MPS,
     FORMAT_SDPA,
 )
@@ -63,6 +65,8 @@ function Model(
         return LP.Model(; kwargs...)
     elseif format == FORMAT_MOF
         return MOF.Model(; kwargs...)
+    elseif format == FORMAT_MOP
+        return MPS.Model(; kwargs...)
     elseif format == FORMAT_MPS
         return MPS.Model(; kwargs...)
     elseif format == FORMAT_SDPA
@@ -76,8 +80,9 @@ function Model(
             (".cbf", CBF.Model),
             (".lp", LP.Model),
             (".mof.json", MOF.Model),
+            (".mop", MPS.Model),
             (".mps", MPS.Model),
-            (".sdpa", SDPA.Model)
+            (".sdpa", SDPA.Model),
         ]
             if endswith(filename, ext) || occursin("$(ext).", filename)
                 return model(; kwargs...)

--- a/test/MPS/MPS.jl
+++ b/test/MPS/MPS.jl
@@ -97,7 +97,7 @@ end
     model_2 = MPS.Model()
     MOIU.loadfromstring!(model_2, """
     variables: x, y, z
-    minobjective: x + y + z
+    minobjective: [x + y + z, x + 2 * y]
     con1: 1.0 * x in Interval(1.0, 5.0)
     con2: 1.0 * x in Interval(2.0, 6.0)
     con3: 1.0 * x in Interval(3.0, 7.0)


### PR DESCRIPTION
This PR adds support for the MOP file format for multi-objective optimization.
See http://moplib.zib.de

It requires https://github.com/JuliaOpt/MathOptInterface.jl/pull/968, so the Manifest is checked in for now.